### PR TITLE
WIP: API Consistency work

### DIFF
--- a/src/LoadTests/ReadAll.cs
+++ b/src/LoadTests/ReadAll.cs
@@ -5,7 +5,7 @@
     using System.Threading;
     using System.Threading.Tasks;
     using EasyConsole;
-    using SqlStreamStore.Streams;
+    using SqlStreamStore;
 
     public class ReadAll : LoadTest
     {

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
@@ -5,7 +5,7 @@
     using SqlStreamStore.Streams;
     using Xunit;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         [Fact]
         public async Task When_append_stream_second_time_with_no_stream_expected_and_different_message_then_should_throw

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteEvent.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteEvent.cs
@@ -7,7 +7,7 @@
     using Xunit;
     using static SqlStreamStore.Deleted;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         [Fact]
         public async Task When_delete_message_then_message_should_be_removed_from_stream()

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteEvent.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteEvent.cs
@@ -4,9 +4,8 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Shouldly;
-    using SqlStreamStore.Streams;
     using Xunit;
-    using static Streams.Deleted;
+    using static SqlStreamStore.Deleted;
 
     public partial class StreamStoreAcceptanceTests
     {

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteStream.cs
@@ -6,7 +6,7 @@
     using Shouldly;
     using SqlStreamStore.Streams;
     using Xunit;
-    using static Streams.Deleted;
+    using static SqlStreamStore.Deleted;
 
     public partial class StreamStoreAcceptanceTests
     {

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.DeleteStream.cs
@@ -8,7 +8,7 @@
     using Xunit;
     using static SqlStreamStore.Deleted;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         [Fact]
         public async Task When_delete_stream_with_no_expected_version_and_read_then_should_get_StreamNotFound()

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadAll.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadAll.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Shouldly;
-    using SqlStreamStore.Streams;
     using Xunit;
 
     public partial class StreamStoreAcceptanceTests

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadAll.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadAll.cs
@@ -6,7 +6,7 @@
     using Shouldly;
     using Xunit;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         [Fact]
         public async Task Can_read_all_forwards()

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadHeadCheckpoint.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadHeadCheckpoint.cs
@@ -4,7 +4,7 @@
     using Shouldly;
     using Xunit;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         [Fact]
         public async Task Given_empty_store_when_get_head_position_Then_should_be_minus_one()

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadHeadCheckpoint.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadHeadCheckpoint.cs
@@ -2,7 +2,6 @@
 {
     using System.Threading.Tasks;
     using Shouldly;
-    using SqlStreamStore.Streams;
     using Xunit;
 
     public partial class StreamStoreAcceptanceTests

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
@@ -7,7 +7,7 @@
     using SqlStreamStore.Infrastructure;
     using Xunit;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         [Theory]
         [MemberData("GetReadStreamForwardsTheories")]

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
@@ -5,7 +5,6 @@
     using System.Threading.Tasks;
     using Shouldly;
     using SqlStreamStore.Infrastructure;
-    using SqlStreamStore.Streams;
     using Xunit;
 
     public partial class StreamStoreAcceptanceTests

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -6,7 +6,7 @@
     using Shouldly;
     using Xunit;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         //TODO: Port some of the tests from AppendStream with regard to expected version to verify behavior of Get/SetStreamMetadata.
 

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Shouldly;
-    using SqlStreamStore.Streams;
     using Xunit;
 
     public partial class StreamStoreAcceptanceTests

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -6,8 +6,6 @@
     using System.Threading.Tasks;
     using Shouldly;
     using SqlStreamStore.Imports.AsyncEx.Nito.AsyncEx.Coordination;
-    using SqlStreamStore.Streams;
-    using SqlStreamStore.Subscriptions;
     using Xunit;
 
     public partial class StreamStoreAcceptanceTests
@@ -809,7 +807,7 @@
                                 caughtUp.SetResult(b);
                             }
                         });
-                    subscription.MaxCountPerRead = 10;
+                    subscription.PageSizePerRead = 10;
                     await caughtUp.Task.WithTimeout(5000);
                     subscription.Dispose();
                 }
@@ -870,7 +868,7 @@
                                 fallenBehind.SetResult(b);
                             }
                         });
-                    subscription.MaxCountPerRead = 10;
+                    subscription.PageSizePerRead = 10;
 
                     await fallenBehind.Task.WithTimeout(5000);
                     subscription.Dispose();

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -8,7 +8,7 @@
     using SqlStreamStore.Imports.AsyncEx.Nito.AsyncEx.Coordination;
     using Xunit;
 
-    public partial class StreamStoreAcceptanceTests
+    public abstract partial class StreamStoreAcceptanceTests
     {
         [Fact]
         public async Task Can_subscribe_to_a_stream_from_start()

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
@@ -10,21 +10,31 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests : IDisposable
+    public abstract partial class StreamStoreAcceptanceTests : IDisposable
     {
         private readonly ITestOutputHelper _testOutputHelper;
         private readonly IDisposable _logCapture;
+        protected readonly StreamStoreAcceptanceTestFixture fixture;
+        protected readonly IStreamStore store;
 
         public StreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper)
         {
             _testOutputHelper = testOutputHelper;
             _logCapture = CaptureLogs(testOutputHelper);
+            fixture = GetFixture();
+            store = fixture.GetStreamStore().Result;
         }
 
         public void Dispose()
         {
+            store.Dispose();
+            fixture.Dispose();
             _logCapture.Dispose();
         }
+
+        protected abstract StreamStoreAcceptanceTestFixture GetFixture();
+
+        protected abstract IDisposable CaptureLogs(ITestOutputHelper testOutputHelper);
 
         [Fact]
         public async Task When_dispose_and_read_then_should_throw()

--- a/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreAcceptanceTests.cs
@@ -7,14 +7,19 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests
+    public class MsSqlStreamStoreAcceptanceTests : StreamStoreAcceptanceTests
     {
-        private StreamStoreAcceptanceTestFixture GetFixture(string schema = "foo")
+        public MsSqlStreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
+        }
+
+        protected override StreamStoreAcceptanceTestFixture GetFixture()
+        {
+            string schema = "foo";
             return new MsSqlStreamStoreFixture(schema);
         }
 
-        private IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
+        protected override IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
         {
             return LoggingHelper.Capture(testOutputHelper);
         }

--- a/src/SqlStreamStore.MsSql/MsSqlScripts/ReadAllForward.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/ReadAllForward.sql
@@ -1,5 +1,5 @@
 /* SQL Server 2008+ */
-     SELECT TOP(@count)
+     SELECT TOP(@pageSize)
             dbo.Streams.IdOriginal As StreamId,
             dbo.Messages.StreamVersion,
             dbo.Messages.Position,

--- a/src/SqlStreamStore.MsSql/MsSqlScripts/ReadAllForwardWithData.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/ReadAllForwardWithData.sql
@@ -1,5 +1,5 @@
 /* SQL Server 2008+ */
-     SELECT TOP(@count)
+     SELECT TOP(@pageSize)
             dbo.Streams.IdOriginal As StreamId,
             dbo.Messages.StreamVersion,
             dbo.Messages.Position,

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.Delete.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.Delete.cs
@@ -6,7 +6,7 @@ namespace SqlStreamStore
     using System.Threading.Tasks;
     using SqlStreamStore.Streams;
     using SqlStreamStore.Infrastructure;
-    using static Streams.Deleted;
+    using static Deleted;
 
     public partial class MsSqlStreamStore
     {

--- a/src/SqlStreamStore.MsSql/StreamIdInfo.cs
+++ b/src/SqlStreamStore.MsSql/StreamIdInfo.cs
@@ -45,6 +45,6 @@ namespace SqlStreamStore
             IdOriginal = idOriginal;
         }
 
-        internal static readonly SqlStreamId Deleted = new StreamIdInfo(Streams.Deleted.DeletedStreamId).SqlStreamId;
+        internal static readonly SqlStreamId Deleted = new StreamIdInfo(SqlStreamStore.Deleted.DeletedStreamId).SqlStreamId;
     }
 }

--- a/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreAcceptanceTests.cs
@@ -7,14 +7,19 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests
+    public class PostgresStreamStoreAcceptanceTests : StreamStoreAcceptanceTests
     {
-        private StreamStoreAcceptanceTestFixture GetFixture(string schema = "foo")
+        public PostgresStreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
+        }
+
+        protected override StreamStoreAcceptanceTestFixture GetFixture()
+        {
+            string schema = "foo";
             return new PostgresStreamStoreFixture(schema);
         }
 
-        private IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
+        protected override IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
         {
             return LoggingHelper.Capture(testOutputHelper);
         }

--- a/src/SqlStreamStore.Tests/InMemory/InMemoryStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.Tests/InMemory/InMemoryStreamStoreAcceptanceTests.cs
@@ -5,14 +5,18 @@ namespace SqlStreamStore
     using SqlStreamStore.InMemory;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests
+    public class InMemoryStreamStoreAcceptanceTests : StreamStoreAcceptanceTests
     {
-        private StreamStoreAcceptanceTestFixture GetFixture()
+        public InMemoryStreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        protected override StreamStoreAcceptanceTestFixture GetFixture()
         {
             return new InMemoryStreamStoreFixture();
         }
 
-        private IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
+        protected override IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
         {
             return LoggingHelper.Capture(testOutputHelper);
         }

--- a/src/SqlStreamStore/AllStreamMessageReceived.cs
+++ b/src/SqlStreamStore/AllStreamMessageReceived.cs
@@ -1,7 +1,6 @@
-﻿namespace SqlStreamStore.Subscriptions
+﻿namespace SqlStreamStore
 {
     using System.Threading.Tasks;
-    using SqlStreamStore.Streams;
 
     /// <summary>
     ///      Repesents a delegate that is invoked when a stream messages has been received in a subscription.

--- a/src/SqlStreamStore/AllSubscriptionDropped.cs
+++ b/src/SqlStreamStore/AllSubscriptionDropped.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Subscriptions
+﻿namespace SqlStreamStore
 {
     using System;
 
@@ -9,10 +9,9 @@
     ///     The source subscription.
     /// </param>
     /// <param name="reason">
-    ///     The subscription dropped reason.
-    /// </param>
+    ///     The subscription dropped reason.</param>
     /// <param name="exception">
     ///     The underlying exception that caused the subscription to drop, if one exists.
     /// </param>
-    public delegate void SubscriptionDropped(IStreamSubscription subscription, SubscriptionDroppedReason reason, Exception exception = null);
+    public delegate void AllSubscriptionDropped(IAllStreamSubscription subscription, SubscriptionDroppedReason reason, Exception exception = null);
 }

--- a/src/SqlStreamStore/AppendResult.cs
+++ b/src/SqlStreamStore/AppendResult.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     /// <summary>
     ///     Represents the result of an append to stream operation.

--- a/src/SqlStreamStore/Deleted.cs
+++ b/src/SqlStreamStore/Deleted.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     using System;
     using StreamStoreStore.Json;

--- a/src/SqlStreamStore/ExpectedVersion.cs
+++ b/src/SqlStreamStore/ExpectedVersion.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     /// <summary>
     ///     Stream expected version constants.

--- a/src/SqlStreamStore/HasCaughtUp.cs
+++ b/src/SqlStreamStore/HasCaughtUp.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Subscriptions
+﻿namespace SqlStreamStore
 {
     /// <summary>
     ///     A delegate that is invoked when a subscription has either caught up or fallen behind.

--- a/src/SqlStreamStore/IAllStreamSubscription.cs
+++ b/src/SqlStreamStore/IAllStreamSubscription.cs
@@ -30,6 +30,6 @@
         /// may result in larger payloads and memory usage whereas smaller values will result in more round-trips
         /// to the store. The correct value requires benchmarking of your application.
         /// </summary>
-        int MaxCountPerRead { get; set; }
+        int PageSizePerRead { get; set; }
     }
 }

--- a/src/SqlStreamStore/IReadonlyStreamStore.cs
+++ b/src/SqlStreamStore/IReadonlyStreamStore.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using SqlStreamStore.Streams;
-    using SqlStreamStore.Subscriptions;
 
     public interface IReadonlyStreamStore : IDisposable
     {

--- a/src/SqlStreamStore/IReadonlyStreamStore.cs
+++ b/src/SqlStreamStore/IReadonlyStreamStore.cs
@@ -15,7 +15,7 @@
         ///     The position to start reading from. Use <see cref="Position.Start"/> to start from the beginning.
         ///     Note: messages that have expired will be filtered out.
         /// </param>
-        /// <param name="maxCount">
+        /// <param name="pageSize">
         ///     The maximum number of messages to read (int.MaxValue is a bad idea).
         /// </param>
         /// <param name="prefetchJsonData">
@@ -31,7 +31,7 @@
         /// </returns>
         Task<ReadAllPage> ReadAllForwards(
             long fromPositionInclusive,
-            int maxCount,
+            int pageSize,
             bool prefetchJsonData = true,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -42,7 +42,7 @@
         ///     The position to start reading from. Use <see cref="Position.End"/> to start from the end.
         ///     Note: messages that have expired will be filtered out.
         /// </param>
-        /// <param name="maxCount">
+        /// <param name="pageSize">
         ///     The maximum number of messages to read (int.MaxValue is a bad idea). 
         /// </param>
         /// <param name="prefetchJsonData">
@@ -58,7 +58,7 @@
         /// </returns>
         Task<ReadAllPage> ReadAllBackwards(
             long fromPositionInclusive,
-            int maxCount,
+            int pageSize,
             bool prefetchJsonData = true,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -72,7 +72,7 @@
         ///     The version of the stream to start reading from. Use <see cref="StreamVersion.Start"/> to read from 
         ///     the start.
         /// </param>
-        /// <param name="maxCount">
+        /// <param name="pageSize">
         ///     The maximum number of messages to read (int.MaxValue is a bad idea).
         /// </param>
         /// <param name="prefetchJsonData">
@@ -89,7 +89,7 @@
         Task<ReadStreamPage> ReadStreamForwards(
             StreamId streamId,
             int fromVersionInclusive,
-            int maxCount,
+            int pageSize,
             bool prefetchJsonData = true,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -103,7 +103,7 @@
         ///     The version of the stream to start reading from. Use <see cref="StreamVersion.End"/> to read from 
         ///     the end.
         /// </param>
-        /// <param name="maxCount">
+        /// <param name="pageSize">
         ///     The maximum number of messages to read (int.MaxValue is a bad idea).
         /// </param>
         /// <param name="prefetchJsonData">
@@ -120,7 +120,7 @@
         Task<ReadStreamPage> ReadStreamBackwards(
             StreamId streamId,
             int fromVersionInclusive,
-            int maxCount,
+            int pageSize,
             bool prefetchJsonData = true,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/SqlStreamStore/IStreamStore.cs
+++ b/src/SqlStreamStore/IStreamStore.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using SqlStreamStore.Streams;
 
     public interface IStreamStore : IReadonlyStreamStore
     {

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -11,7 +11,7 @@ namespace SqlStreamStore
     using SqlStreamStore.Streams;
     using SqlStreamStore.Subscriptions;
     using StreamStoreStore.Json;
-    using static Streams.Deleted;
+    using static SqlStreamStore.Deleted;
 
     /// <summary>
     ///     Represents an in-memory implementation of a stream store. Use for testing or high/speed + volatile scenarios.

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -281,7 +281,7 @@ namespace SqlStreamStore
             AppendToStreamInternal(DeletedStreamId, ExpectedVersion.Any, new[] { streamDeletedEvent });
         }
 
-        protected override Task<ReadAllPage> ReadAllForwardsInternal(long fromPositionExlusive, int maxCount,
+        protected override Task<ReadAllPage> ReadAllForwardsInternal(long fromPositionExlusive, int pageSize,
             bool prefetch, ReadNextAllPage readNext, CancellationToken cancellationToken)
         {
             GuardAgainstDisposed();
@@ -312,7 +312,7 @@ namespace SqlStreamStore
                 }
 
                 var messages = new List<StreamMessage>();
-                while(maxCount > 0 && current != null)
+                while(pageSize > 0 && current != null)
                 {
                     StreamMessage message;
                     if (prefetch)
@@ -345,7 +345,7 @@ namespace SqlStreamStore
                             });
                     }
                     messages.Add(message);
-                    maxCount--;
+                    pageSize--;
                     previous = current;
                     current = current.Next;
                 }
@@ -368,7 +368,7 @@ namespace SqlStreamStore
 
         protected override Task<ReadAllPage> ReadAllBackwardsInternal(
             long fromPositionExclusive,
-            int maxCount,
+            int pageSize,
             bool prefetch,
             ReadNextAllPage readNext,
             CancellationToken cancellationToken)
@@ -405,7 +405,7 @@ namespace SqlStreamStore
                 }
 
                 var messages = new List<StreamMessage>();
-                while(maxCount > 0 && current != _allStream.First)
+                while(pageSize > 0 && current != _allStream.First)
                 {
                     StreamMessage message;
                     if (prefetch)
@@ -439,7 +439,7 @@ namespace SqlStreamStore
                     }
                     messages.Add(message);
 
-                    maxCount--;
+                    pageSize--;
                     previous = current;
                     current = current.Previous;
                 }
@@ -471,7 +471,7 @@ namespace SqlStreamStore
             }
         }
 
-        protected override Task<ReadStreamPage> ReadStreamForwardsInternal(string streamId, int start, int count, bool prefetch, ReadNextStreamPage readNext, CancellationToken cancellationToken)
+        protected override Task<ReadStreamPage> ReadStreamForwardsInternal(string streamId, int start, int pageSize, bool prefetch, ReadNextStreamPage readNext, CancellationToken cancellationToken)
         {
             GuardAgainstDisposed();
             cancellationToken.ThrowIfCancellationRequested();
@@ -498,7 +498,7 @@ namespace SqlStreamStore
                 var messages = new List<StreamMessage>();
                 var i = start;
 
-                while(i < stream.Messages.Count && count > 0)
+                while(i < stream.Messages.Count && pageSize > 0)
                 {
                     var inMemorymessage = stream.Messages[i];
                     StreamMessage message;
@@ -529,7 +529,7 @@ namespace SqlStreamStore
                     messages.Add(message);
 
                     i++;
-                    count--;
+                    pageSize--;
                 }
 
                 var lastStreamVersion = stream.CurrentVersion;
@@ -567,7 +567,7 @@ namespace SqlStreamStore
         protected override Task<ReadStreamPage> ReadStreamBackwardsInternal(
             string streamId,
             int fromVersionInclusive,
-            int count,
+            int pageSize,
             bool prefetch,
             ReadNextStreamPage readNext,
             CancellationToken cancellationToken)
@@ -595,7 +595,7 @@ namespace SqlStreamStore
 
                 var messages = new List<StreamMessage>();
                 var i = fromVersionInclusive == StreamVersion.End ? stream.Messages.Count - 1 : fromVersionInclusive;
-                while (i >= 0 && count > 0)
+                while (i >= 0 && pageSize > 0)
                 {
                     var inMemorymessage = stream.Messages[i];
                     StreamMessage message;
@@ -626,7 +626,7 @@ namespace SqlStreamStore
                     messages.Add(message);
 
                     i--;
-                    count--;
+                    pageSize--;
                 }
 
                 var lastStreamVersion = stream.Messages.Count > 0 

--- a/src/SqlStreamStore/Infrastructure/StreamStoreConstants.cs
+++ b/src/SqlStreamStore/Infrastructure/StreamStoreConstants.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SqlStreamStore.Infrastructure
+{
+    public class StreamStoreConstants
+    {
+        public static readonly long MinimumReadAllForwardPosition = 0;
+        public static readonly int MinimumPageSize = 1;
+    }
+}

--- a/src/SqlStreamStore/NewStreamMessage.cs
+++ b/src/SqlStreamStore/NewStreamMessage.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     using System;
     using SqlStreamStore.Imports.Ensure.That;

--- a/src/SqlStreamStore/PageReadStatus.cs
+++ b/src/SqlStreamStore/PageReadStatus.cs
@@ -1,4 +1,4 @@
-namespace SqlStreamStore.Streams
+namespace SqlStreamStore
 {
     public enum PageReadStatus
     {

--- a/src/SqlStreamStore/Position.cs
+++ b/src/SqlStreamStore/Position.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     /// <summary>
     ///     Constants for store position

--- a/src/SqlStreamStore/ReadAllPage.cs
+++ b/src/SqlStreamStore/ReadAllPage.cs
@@ -1,5 +1,6 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
+    using SqlStreamStore.Streams;
     using System.Threading;
     using System.Threading.Tasks;
 

--- a/src/SqlStreamStore/ReadDirection.cs
+++ b/src/SqlStreamStore/ReadDirection.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     public enum ReadDirection
     {

--- a/src/SqlStreamStore/ReadStreamPage.cs
+++ b/src/SqlStreamStore/ReadStreamPage.cs
@@ -1,5 +1,6 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
+    using SqlStreamStore.Streams;
     using System;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/SqlStreamStore/StreamId.cs
+++ b/src/SqlStreamStore/StreamId.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     using System;
     using SqlStreamStore.Imports.Ensure.That;

--- a/src/SqlStreamStore/StreamMessage.cs
+++ b/src/SqlStreamStore/StreamMessage.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     using System;
     using System.Threading;

--- a/src/SqlStreamStore/StreamMessageExtensions.cs
+++ b/src/SqlStreamStore/StreamMessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/SqlStreamStore/StreamMessageReceived.cs
+++ b/src/SqlStreamStore/StreamMessageReceived.cs
@@ -1,8 +1,7 @@
-﻿namespace SqlStreamStore.Subscriptions
+﻿namespace SqlStreamStore
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using SqlStreamStore.Streams;
 
     /// <summary>
     ///       Repesents a delegate that is invoked when a stream messages has been received in a subscription.

--- a/src/SqlStreamStore/StreamMetadataResult.cs
+++ b/src/SqlStreamStore/StreamMetadataResult.cs
@@ -1,4 +1,4 @@
-namespace SqlStreamStore.Streams
+namespace SqlStreamStore
 {
     public class StreamMetadataResult
     {

--- a/src/SqlStreamStore/StreamVersion.cs
+++ b/src/SqlStreamStore/StreamVersion.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     /// <summary>
     /// Constants for stream version

--- a/src/SqlStreamStore/SubscriptionDropped.cs
+++ b/src/SqlStreamStore/SubscriptionDropped.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Subscriptions
+﻿namespace SqlStreamStore
 {
     using System;
 
@@ -9,9 +9,10 @@
     ///     The source subscription.
     /// </param>
     /// <param name="reason">
-    ///     The subscription dropped reason.</param>
+    ///     The subscription dropped reason.
+    /// </param>
     /// <param name="exception">
     ///     The underlying exception that caused the subscription to drop, if one exists.
     /// </param>
-    public delegate void AllSubscriptionDropped(IAllStreamSubscription subscription, SubscriptionDroppedReason reason, Exception exception = null);
+    public delegate void SubscriptionDropped(IStreamSubscription subscription, SubscriptionDroppedReason reason, Exception exception = null);
 }

--- a/src/SqlStreamStore/SubscriptionDroppedReason.cs
+++ b/src/SqlStreamStore/SubscriptionDroppedReason.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Subscriptions
+﻿namespace SqlStreamStore
 {
     public enum SubscriptionDroppedReason
     {

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -71,7 +71,7 @@
 
         public Task Started => _started.Task;
 
-        public int MaxCountPerRead
+        public int PageSizePerRead
         {
             get { return _pageSize; }
             set { _pageSize = (value <= 0) ? 1 : value; }
@@ -174,7 +174,7 @@
             try
             {
                 readAllPage = await _readonlyStreamStore
-                    .ReadAllForwards(_nextPosition, MaxCountPerRead, _prefetchJsonData, _disposed.Token)
+                    .ReadAllForwards(_nextPosition, PageSizePerRead, _prefetchJsonData, _disposed.Token)
                     .NotOnCapturedContext();
             }
             catch(ObjectDisposedException)

--- a/src/SqlStreamStore/WrongExpectedVersionException.cs
+++ b/src/SqlStreamStore/WrongExpectedVersionException.cs
@@ -1,4 +1,4 @@
-﻿namespace SqlStreamStore.Streams
+﻿namespace SqlStreamStore
 {
     using System;
 


### PR DESCRIPTION
- Should `StreamMessage.GetJsonData()` repeat the database lookup, or cache the value on first call and return it on subsequent lookups?
