### PR TITLE
migrate project to netstandard2.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,3 @@
-#tool "nuget:?package=xunit.runner.console&version=2.1.0"
-
 #addin "Cake.FileHelpers"
 
 var target          = Argument("target", "Default");
@@ -19,7 +17,6 @@ Task("RestorePackages")
     .Does(() =>
 {
 	DotNetCoreRestore(solution);
-	NuGetRestore(solution);
 });
 
 Task("Build")
@@ -43,13 +40,14 @@ Task("RunTests")
 
     foreach(var testProject in testProjects)
     {
-        var projectDir = "./src/"+ testProject + "/";
-        var settings = new ProcessSettings
+        var projectDir = "./src/" + testProject + "/";
+        var projectFile = testProject + ".csproj";
+        var settings = new DotNetCoreTestSettings
         {
-            Arguments = "xunit",
+            Configuration = configuration,
             WorkingDirectory = projectDir
         };
-        StartProcess("dotnet", settings);
+        DotNetCoreTest(projectFile, settings);
     }
 });
 

--- a/build.ps1
+++ b/build.ps1
@@ -31,10 +31,10 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$CakeVersion = "0.19.3"
-$DotNetChannel = "preview";
-$DotNetVersion = "1.0.3";
-$DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
+$CakeVersion = "0.21.1"
+$DotNetChannel = "Current";
+$DotNetVersion = "2.0.0";
+$DotNetInstallerUri = "https://dot.net/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
 # Make sure tools folder exists

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,26 +5,15 @@
     <Authors>Damian Hickey</Authors>
     <PackageProjectUrl>https://github.com/damianh/SqlStreamStore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/damianh/SqlStreamStore/blob/master/LICENSE</PackageLicenseUrl>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net461' ">true</DisableImplicitFrameworkReferences>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cqrs;event-sourcing;event-store;stream-store</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);LIBLOG_PORTABLE</DefineConstants>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <DebugType>full</DebugType>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(MSBuildProjectName)' != 'SqlStreamStore' ">
     <ProjectReference Include="../SqlStreamStore/SqlStreamStore.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-  </ItemGroup>
 </Project>

--- a/src/LoadTests/LoadTests.csproj
+++ b/src/LoadTests/LoadTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>SQL Stream Store</AssemblyTitle>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <RuntimeIdentifiers>win10-x64;osx.10.11-x64;ubuntu.16.10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
     <OutputType>exe</OutputType>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>

--- a/src/LoadTests/LoadTests.csproj
+++ b/src/LoadTests/LoadTests.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <AssemblyTitle>SQL Stream Store</AssemblyTitle>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <OutputType>exe</OutputType>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="EasyConsole" Version="1.1.0" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.2.0" />
   </ItemGroup>
 

--- a/src/LoadTests/packages.config
+++ b/src/LoadTests/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="EasyConsole" version="1.1.0" targetFramework="net46" />
-  <package id="Serilog" version="2.3.0" targetFramework="net46" />
-  <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net46" />
-</packages>

--- a/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
+++ b/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>SqlStreamStore.MsSql.Tests</AssemblyName>
     <PackageId>SqlStreamStore.MsSql.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,23 +23,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Shouldly" Version="2.8.2" />
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <!-- <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" /> -->
+    <PackageReference Include="Shouldly" Version="2.8.3" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="System.Data.SqlLocalDb" Version="1.15.0" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SqlStreamStore.MsSql/MsSqlScripts/Scripts.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/Scripts.cs
@@ -3,9 +3,7 @@
     using System;
     using System.Collections.Concurrent;
     using System.IO;
-#if NETSTANDARD1_3
     using System.Reflection;
-#endif
 
     internal class Scripts
     {
@@ -67,11 +65,7 @@
             return _scripts.GetOrAdd(name,
                 key =>
                 {
-#if NETSTANDARD1_3
                     using (Stream stream = typeof(Scripts).GetTypeInfo().Assembly.GetManifestResourceStream("SqlStreamStore.MsSqlScripts." + key + ".sql"))
-#elif NET461
-                    using (Stream stream = typeof(Scripts).Assembly.GetManifestResourceStream("SqlStreamStore.MsSqlScripts." + key + ".sql"))
-#endif
                     {
                         if (stream == null)
                         {

--- a/src/SqlStreamStore.MsSql/SqlStreamStore.MsSql.csproj
+++ b/src/SqlStreamStore.MsSql/SqlStreamStore.MsSql.csproj
@@ -3,13 +3,12 @@
   <PropertyGroup>
     <Description>SQL Server (2012+) provider for SQL Stream Store</Description>
     <AssemblyTitle>SQL Stream Store - SQL Server (2012+) Provider</AssemblyTitle>
-    <TargetFrameworks>netstandard1.3;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SqlStreamStore.MsSql</AssemblyName>
     <PackageId>SqlStreamStore.MsSql</PackageId>
     <RootNamespace>SqlStreamStore</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
     <PackageVersion>1.0.1</PackageVersion>
   </PropertyGroup>
 
@@ -21,15 +20,8 @@
     <ProjectReference Include="..\SqlStreamStore\SqlStreamStore.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+  <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
+++ b/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>SqlStreamStore.Postgres.Tests</AssemblyName>
     <PackageId>SqlStreamStore.Postgres.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
@@ -20,23 +19,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Shouldly" Version="2.8.2" />
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <!-- <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" /> -->
+    <PackageReference Include="Shouldly" Version="2.8.3" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-    <PackageReference Include="Npgsql" Version="3.2.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Npgsql" Version="3.2.5" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/Scripts.cs
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/Scripts.cs
@@ -53,11 +53,7 @@
             return _scripts.GetOrAdd(name,
                 key =>
                 {
-#if NETSTANDARD1_3
                     using (Stream stream = typeof(Scripts).GetTypeInfo().Assembly.GetManifestResourceStream("SqlStreamStore.Postgres.PgSqlScripts." + key + ".pgsql"))
-#elif NET461
-                    using (Stream stream = typeof(Scripts).Assembly.GetManifestResourceStream("SqlStreamStore.Postgres.PgSqlScripts." + key + ".pgsql"))
-#endif
                     {
                         if (stream == null)
                         {

--- a/src/SqlStreamStore.Postgres/SqlStreamStore.Postgres.csproj
+++ b/src/SqlStreamStore.Postgres/SqlStreamStore.Postgres.csproj
@@ -2,16 +2,15 @@
   <PropertyGroup>
     <Description>Postgre SQL provider for SQL StreamStore</Description>
     <AssemblyTitle>Stream Store - Postgres</AssemblyTitle>
-    <TargetFrameworks>netstandard1.3;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>SqlStreamStore.Postgres</AssemblyName>
     <PackageId>SqlStreamStore.Postgres</PackageId>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="3.2.2" />
+    <PackageReference Include="Npgsql" Version="3.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
+++ b/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>SqlStreamStore.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
@@ -19,20 +18,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Shouldly" Version="2.8.2" />
-    <PackageReference Include="Serilog" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <!-- <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" /> -->
+    <PackageReference Include="Shouldly" Version="2.8.3" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlStreamStore/SimpleJson.cs
+++ b/src/SqlStreamStore/SimpleJson.cs
@@ -2132,16 +2132,3 @@ namespace StreamStoreStore.Json
 // ReSharper restore LoopCanBeConvertedToQuery
 // ReSharper restore RedundantExplicitArrayCreation
 // ReSharper restore SuggestUseVarKeywordEvident
-
-#if NETSTANDARD1_3
-namespace System.Runtime.Serialization
-{
-    public class SerializationException : Exception
-    {
-        public SerializationException(string message) : base(message)
-        {
-
-        }
-    }
-}
-#endif

--- a/src/SqlStreamStore/SqlStreamStore.csproj
+++ b/src/SqlStreamStore/SqlStreamStore.csproj
@@ -3,15 +3,19 @@
   <PropertyGroup>
     <Description>A libray for writing and reading streams (also known as an 'event store') with a focus on SQL based implementations. This contains the core interfaces, abstractions and an in-memory implementation for tests.</Description>
     <AssemblyTitle>SQL Stream Store</AssemblyTitle>
-    <TargetFrameworks>netstandard1.3;net461</TargetFrameworks>
-    <DefineConstants>$(DefineConstants);LIBLOG_PUBLIC</DefineConstants>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);LIBLOG_PUBLIC;LIBLOG_PORTABLE</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SqlStreamStore</AssemblyName>
     <PackageId>SqlStreamStore</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <PackageVersion>1.0.0</PackageVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="SimpleJson" Version="0.38.0">
@@ -20,27 +24,6 @@
     <PackageReference Include="LibLog" Version="4.2.6">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);LIBLOG_PORTABLE</DefineConstants>
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <DebugType>full</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Core" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -16,11 +16,7 @@
     public sealed class AllStreamSubscription : IAllStreamSubscription
     {
         public const int DefaultPageSize = 10;
-#if NET461
-        private static readonly ILog s_logger = LogProvider.GetCurrentClassLogger();
-#elif NETSTANDARD1_3
         private static readonly ILog s_logger = LogProvider.GetLogger("SqlStreamStore.Subscriptions.AllStreamSubscription");
-#endif
         private int _pageSize = DefaultPageSize;
         private long _nextPosition;
         private readonly IReadonlyStreamStore _readonlyStreamStore;

--- a/src/SqlStreamStore/Subscriptions/PollingStreamStoreNotifier.cs
+++ b/src/SqlStreamStore/Subscriptions/PollingStreamStoreNotifier.cs
@@ -12,11 +12,8 @@
     /// </summary>
     public sealed class PollingStreamStoreNotifier : IStreamStoreNotifier
     {
-#if NET461
-        private static readonly ILog s_logger = LogProvider.GetCurrentClassLogger();
-#elif NETSTANDARD1_3
         private static readonly ILog s_logger = LogProvider.GetLogger("SqlStreamStore.Subscriptions.PollingStreamStoreNotifier");
-#endif
+
         private readonly CancellationTokenSource _disposed = new CancellationTokenSource();
         private readonly Func<CancellationToken, Task<long>> _readHeadPosition;
         private readonly int _interval;

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -18,11 +18,8 @@
         ///     The default page size to read.
         /// </summary>
         public const int DefaultPageSize = 10;
-#if NET461
-        private static readonly ILog s_logger = LogProvider.GetCurrentClassLogger();
-#elif NETSTANDARD1_3
         private static readonly ILog s_logger = LogProvider.GetLogger("SqlStreamStore.Subscriptions.StreamSubscription");
-#endif
+
         private int _pageSize = DefaultPageSize;
         private int _nextVersion;
         private readonly int? _continueAfterVersion;


### PR DESCRIPTION
Migrated all the projects and build to netstandard 2.0

Had to remove support for sqllocaldb.

Maybe, it would be handy to extract sqllocaldb instances and tools to build script (using preinstalled sqllocaldb.exe utility). And database instance for tests can be feed using external settings file.

NOTE: still not really going to work in linux, due to SqlServer dependency and 'integrated security'.

to run load tests it's best to
```
cd src\LoadTest
dotnet publish -c Release -r win10-x64 -f netcoreapp2.0
.\bin\Release\netcoreapp2.0\win10-x64\LoadTests.exe
```

Anyway, please review.