### PR TITLE
Soften any assertions on Position such that it checks that it remains same or increases but do not assert specific value or sequentiality

### DIFF
--- a/src/LoadTests/StreamSubscription.cs
+++ b/src/LoadTests/StreamSubscription.cs
@@ -34,8 +34,9 @@ namespace LoadTests
 
             for(int i = 0; i < numberOfStreams; i++)
             {
-                var subscription =
-                    streamStore.SubscribeToStream($"stream-{i}", null,
+                var subscription = streamStore.SubscribeToStream(
+                        $"stream-{i}",
+                        StreamVersion.None,
                         (_, __, ___) =>
                         {
                             Interlocked.Increment(ref messagesReceived);

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTestFixture.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTestFixture.cs
@@ -12,5 +12,7 @@ namespace SqlStreamStore
 
         public virtual void Dispose()
         {}
+
+        public abstract long MinPosition { get; }
     }
 }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
@@ -61,15 +61,14 @@
                 using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
-                    await store
+                    var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2));
 
-                    var result = await store
+                    var result2 = await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2));
 
-                    result.CurrentVersion.ShouldBe(1);
-                    result.CurrentPosition.ShouldBe(1L);
-                    //result.NextExpectedVersion.ShouldBe(1);
+                    result2.CurrentVersion.ShouldBe(1);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
                 }
             }
         }
@@ -127,15 +126,14 @@
                 using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
-                    await store
+                    var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2));
 
-                    var result =
+                    var result2 =
                         await store.AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1));
 
-                    result.CurrentVersion.ShouldBe(1);
-                    result.CurrentPosition.ShouldBe(1L);
-                    //result.NextExpectedVersion.ShouldBe(0);
+                    result2.CurrentVersion.ShouldBe(1);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
                 }
             }
         }
@@ -189,14 +187,14 @@
                 using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
-                    var result = await store
+                    var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
 
-                    result =
-                        await store.AppendToStream(streamId, result.CurrentVersion, CreateNewStreamMessages(4, 5, 6));
+                    var result2 =
+                        await store.AppendToStream(streamId, result1.CurrentVersion, CreateNewStreamMessages(4, 5, 6));
 
-                    result.CurrentVersion.ShouldBe(5);
-                    result.CurrentPosition.ShouldBe(5L);
+                    result2.CurrentVersion.ShouldBe(5);
+                    result2.CurrentPosition.ShouldBeGreaterThan(result1.CurrentPosition);
                 }
             }
         }
@@ -209,14 +207,14 @@
                 using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
-                    var result = await store
+                    var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
 
-                    result =
-                        await store.AppendToStream(streamId, result.CurrentVersion, CreateNewStreamMessages(4)[0]);
+                    var result2 =
+                        await store.AppendToStream(streamId, result1.CurrentVersion, CreateNewStreamMessages(4)[0]);
 
-                    result.CurrentVersion.ShouldBe(3);
-                    result.CurrentPosition.ShouldBe(3L);
+                    result2.CurrentVersion.ShouldBe(3);
+                    result2.CurrentPosition.ShouldBeGreaterThan(result1.CurrentPosition);
                 }
             }
         }
@@ -252,14 +250,13 @@
                     const string streamId = "stream-1";
                     await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
-                    await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
+                    var result1 = await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
 
-                    var result = await
+                    var result2 = await
                             store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
 
-                    result.CurrentVersion.ShouldBe(5);
-                    result.CurrentPosition.ShouldBe(5L);
-                    //result.NextExpectedVersion.ShouldBe(5);
+                    result2.CurrentVersion.ShouldBe(5);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
                 }
             }
         }
@@ -274,14 +271,13 @@
                     const string streamId = "stream-1";
                     await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
-                    await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4)[0]);
+                    var result1 = await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4)[0]);
 
-                    var result = await
+                    var result2 = await
                             store.AppendToStream(streamId, 2, CreateNewStreamMessages(4)[0]);
 
-                    result.CurrentVersion.ShouldBe(3);
-                    result.CurrentPosition.ShouldBe(3L);
-                    //result.NextExpectedVersion.ShouldBe(4);
+                    result2.CurrentVersion.ShouldBe(3);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
                 }
             }
         }
@@ -318,14 +314,13 @@
                     const string streamId = "stream-1";
                     await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
-                    await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
+                    var result1 = await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
 
-                    var result = await
+                    var result2 = await
                             store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5));
 
-                    result.CurrentVersion.ShouldBe(5);
-                    result.CurrentPosition.ShouldBe(5L);
-                    //result.NextExpectedVersion.ShouldBe(5);
+                    result2.CurrentVersion.ShouldBe(5);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
                 }
             }
         }
@@ -340,14 +335,13 @@
                     const string streamId = "stream-1";
                     await store
                         .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
-                    await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4)[0]);
+                    var result1 = await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4)[0]);
 
-                    var result = await
+                    var result2 = await
                             store.AppendToStream(streamId, 1, CreateNewStreamMessages(3)[0]);
 
-                    result.CurrentVersion.ShouldBe(3);
-                    result.CurrentPosition.ShouldBe(3L);
-                    //result.NextExpectedVersion.ShouldBe(4);
+                    result2.CurrentVersion.ShouldBe(3);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
                 }
             }
         }
@@ -406,7 +400,7 @@
                         await store.AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1)[0]);
 
                     result.CurrentVersion.ShouldBe(0);
-                    result.CurrentPosition.ShouldBe(0L);
+                    result.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition);
 
                     var page = await store
                         .ReadStreamForwards(streamId, StreamVersion.Start, 2);
@@ -452,15 +446,13 @@
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
 
                     result1.CurrentVersion.ShouldBe(2);
-                    result1.CurrentPosition.ShouldBe(2L);
-                    //result1.NextExpectedVersion.ShouldBe(2);
+                    result1.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition + 2L);
 
                     var result2 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
 
                     result2.CurrentVersion.ShouldBe(2);
-                    result2.CurrentPosition.ShouldBe(2L);
-                    //result2.NextExpectedVersion.ShouldBe(2);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
 
                     var page = await store
                         .ReadStreamForwards(streamId, StreamVersion.Start, 10);
@@ -482,15 +474,13 @@
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1)[0]);
 
                     result1.CurrentVersion.ShouldBe(0);
-                    result1.CurrentPosition.ShouldBe(0L);
-                    //result1.NextExpectedVersion.ShouldBe(0);
+                    result1.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition);
 
                     var result2 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1)[0]);
 
                     result2.CurrentVersion.ShouldBe(0);
-                    result2.CurrentPosition.ShouldBe(0L);
-                    //result2.NextExpectedVersion.ShouldBe(0);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
 
                     var page = await store
                         .ReadStreamForwards(streamId, StreamVersion.Start, 3);
@@ -536,15 +526,13 @@
                     var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
                     result1.CurrentVersion.ShouldBe(2);
-                    result1.CurrentPosition.ShouldBe(2L);
-                    //result1.NextExpectedVersion.ShouldBe(2);
+                    result1.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition + 2L);
 
                     var result2 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2));
 
                     result2.CurrentVersion.ShouldBe(2);
-                    result2.CurrentPosition.ShouldBe(2L);
-                    //result1.NextExpectedVersion.ShouldBe(1);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
 
                     var page = await store
                         .ReadStreamForwards(streamId, StreamVersion.Start, 10);
@@ -565,15 +553,13 @@
                     var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
                     result1.CurrentVersion.ShouldBe(2);
-                    result1.CurrentPosition.ShouldBe(2L);
-                    //result1.NextExpectedVersion.ShouldBe(2);
+                    result1.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition + 2L);
 
                     var result2 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1)[0]);
 
                     result2.CurrentVersion.ShouldBe(2);
-                    result2.CurrentPosition.ShouldBe(2L);
-                    //result1.NextExpectedVersion.ShouldBe(1);
+                    result2.CurrentPosition.ShouldBe(result1.CurrentPosition);
 
                     var page = await store
                         .ReadStreamForwards(streamId, StreamVersion.Start, 4);
@@ -616,12 +602,12 @@
                     var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
                     result1.CurrentVersion.ShouldBe(2);
-                    result1.CurrentPosition.ShouldBe(2L);
+                    result1.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition + 2L);
 
                     var result2 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(4, 5, 6));
                     result2.CurrentVersion.ShouldBe(5);
-                    result2.CurrentPosition.ShouldBe(5L);
+                    result2.CurrentPosition.ShouldBeGreaterThanOrEqualTo(result1.CurrentPosition + 3L);
 
                     var page = await store
                         .ReadStreamForwards(streamId, StreamVersion.Start, 10);
@@ -643,12 +629,12 @@
                     var result1 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
                     result1.CurrentVersion.ShouldBe(2);
-                    result1.CurrentPosition.ShouldBe(2L);
+                    result1.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition + 2L);
 
                     var result2 = await store
                         .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(4)[0]);
                     result2.CurrentVersion.ShouldBe(3);
-                    result2.CurrentPosition.ShouldBe(3L);
+                    result2.CurrentPosition.ShouldBeGreaterThanOrEqualTo(result1.CurrentPosition + 1L);
 
                     var page = await store
                         .ReadStreamForwards(streamId, StreamVersion.Start, 5);
@@ -692,7 +678,7 @@
                     var result = await store.AppendToStream(streamId, 2, new NewStreamMessage[0]);
 
                     result.CurrentVersion.ShouldBe(2);
-                    result.CurrentPosition.ShouldBe(2);
+                    result.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition + 2L);
                 }
             }
         }
@@ -709,7 +695,7 @@
                         .AppendToStream(streamId, ExpectedVersion.NoStream, new NewStreamMessage[0]);
 
                     result.CurrentVersion.ShouldBe(-1);
-                    result.CurrentPosition.ShouldBe(-1);
+                    result.CurrentPosition.ShouldBeLessThan(fixture.MinPosition);
                 }
             }
         }
@@ -774,13 +760,13 @@
                         await store.AppendToStream(streamId1, expectedVersion, CreateNewStreamMessages(1, 2, 3));
 
                     result1.CurrentVersion.ShouldBe(2);
-                    result1.CurrentPosition.ShouldBe(2L);
+                    result1.CurrentPosition.ShouldBeGreaterThanOrEqualTo(fixture.MinPosition + 2L);
 
                     var result2 =
                         await store.AppendToStream(streamId2, expectedVersion, CreateNewStreamMessages(1, 2, 3));
 
                     result2.CurrentVersion.ShouldBe(2);
-                    result2.CurrentPosition.ShouldBe(5L);
+                    result2.CurrentPosition.ShouldBeGreaterThanOrEqualTo(result1.CurrentPosition + 2L);
                 }
             }
         }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -29,7 +29,7 @@
                     var receivedMessages = new List<StreamMessage>();
                     using (var subscription = store.SubscribeToStream(
                         streamId1,
-                        null,
+                        StreamVersion.None,
                         (_, message, ct) =>
                         {
                             receivedMessages.Add(message);
@@ -67,7 +67,7 @@
                     var done = new TaskCompletionSource<IStreamSubscription>();
                     using (var subscription = store.SubscribeToStream(
                         streamId,
-                        null,
+                        StreamVersion.None,
                         (sub, _, ct) =>
                         {
                             done.SetResult(sub);
@@ -95,7 +95,7 @@
                     var receivedMessages = new List<StreamMessage>();
                     using (var subscription = store.SubscribeToStream(
                         streamId,
-                        null,
+                        StreamVersion.None,
                         (_, message, ct) =>
                         {
                             receivedMessages.Add(message);
@@ -136,7 +136,7 @@
                     var receiveMessages = new TaskCompletionSource<StreamMessage>();
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using(store.SubscribeToAll(
-                        null,
+                        Position.None,
                         (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} " +
@@ -171,7 +171,7 @@
 
                     var done = new TaskCompletionSource<IAllStreamSubscription>();
                     using (var subscription = store.SubscribeToAll(
-                        null,
+                        Position.None,
                         (sub, _) =>
                         {
                             done.SetResult(sub);
@@ -200,7 +200,7 @@
                     var receiveMessages = new TaskCompletionSource<StreamMessage>();
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (store.SubscribeToAll(
-                        null,
+                        Position.None,
                         (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} {message.StreamVersion} {message.Position}");
@@ -412,7 +412,7 @@
 
                     var subscriptions = Enumerable.Range(0, subscriptionCount)
                         .Select(index => store.SubscribeToAll(
-                            null,
+                            Position.None,
                             (_, message) =>
                             {
                                 if(message.StreamVersion == 1)
@@ -495,7 +495,7 @@
                     var receiveMessage = new TaskCompletionSource<StreamMessage>();
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (store.SubscribeToAll(
-                        null,
+                        Position.None,
                         (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} " +
@@ -540,7 +540,7 @@
                     };
                     string streamId = "stream-1";
                     using(store.SubscribeToStream("stream-1",
-                        null,
+                        StreamVersion.None,
                         messageReceived,
                         subscriptionDropped))
                     {
@@ -589,7 +589,7 @@
                     var tcs = new TaskCompletionSource<IStreamSubscription>();
                     var subscription = store.SubscribeToStream(
                         "stream-1",
-                        null,
+                        StreamVersion.None,
                         (_, __, ___) => Task.CompletedTask,
                         (sub, _, __) =>
                         {
@@ -674,7 +674,7 @@
                     };
                     string streamId = "stream-1";
                     using (store.SubscribeToAll(
-                        null,
+                        Position.None,
                         messageReceived,
                         subscriptionDropped))
                     {
@@ -800,7 +800,7 @@
                     await AppendMessages(store, streamId, 30);
                     var caughtUp = new TaskCompletionSource<bool>();
                     var subscription = store.SubscribeToAll(
-                        null,
+                        Position.None,
                         (_, __) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
@@ -828,7 +828,7 @@
                     var caughtUp = new TaskCompletionSource<bool>();
                     var numberOfCaughtUps = 0;
                     var subscription = store.SubscribeToAll(
-                        null,
+                        Position.None,
                         (_, __) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
@@ -863,7 +863,7 @@
                     var caughtUp = new TaskCompletionSource<bool>();
                     var subscription = store.SubscribeToStream(
                         streamId,
-                        null,
+                        StreamVersion.None,
                         (_, __, ___) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
@@ -892,7 +892,7 @@
                     bool caughtUp = false;
 
                     var subscription = store.SubscribeToAll(
-                        null,
+                        Position.None,
                         (_, __) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
@@ -927,7 +927,7 @@
 
                     var subscription = store.SubscribeToStream(
                         streamId,
-                        null,
+                        StreamVersion.None,
                         (_, __, ___) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
@@ -957,7 +957,7 @@
                 var subscriptionDropped = new TaskCompletionSource<SubscriptionDroppedReason>();
                 var subscription = store.SubscribeToStream(
                     "stream-1",
-                    null,
+                    StreamVersion.None,
                     (_, __, ___) => Task.CompletedTask,
                     subscriptionDropped: (streamSubscription, reason, exception) =>
                     {
@@ -980,7 +980,7 @@
                 var store = await fixture.GetStreamStore();
                 var subscriptionDropped = new TaskCompletionSource<SubscriptionDroppedReason>();
                 var subscription = store.SubscribeToAll(
-                    null,
+                    Position.None,
                     (_, __) => Task.CompletedTask,
                     subscriptionDropped: (streamSubscription, reason, exception) =>
                     {
@@ -1008,7 +1008,7 @@
                     string streamIdReceived = null;
                     using (store.SubscribeToStream(
                         streamId1,
-                        null,
+                        StreamVersion.None,
                         (_, message, ct) =>
                         {
                             streamIdReceived = message.StreamId;

--- a/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
+++ b/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
@@ -23,6 +23,8 @@ namespace SqlStreamStore
             ConnectionString = CreateConnectionString();
         }
 
+        public override long MinPosition => 0;
+
         public override async Task<IStreamStore> GetStreamStore()
         {
             await CreateDatabase();

--- a/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
+++ b/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectCapability Include="ShowFilesOutsideOfProject" />
     <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" />
   </ItemGroup>
 
@@ -24,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <!-- <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" /> -->
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.1" />

--- a/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreFixture.cs
+++ b/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreFixture.cs
@@ -19,6 +19,8 @@ namespace SqlStreamStore
             ConnectionString = CreateConnectionString();
         }
 
+        public override long MinPosition => 1;
+
         public override async Task<IStreamStore> GetStreamStore()
         {
             await CreateDatabase();

--- a/src/SqlStreamStore.Tests/InMemory/InMemoryStreamStoreFixture.cs
+++ b/src/SqlStreamStore.Tests/InMemory/InMemoryStreamStoreFixture.cs
@@ -10,5 +10,7 @@ namespace SqlStreamStore.InMemory
             IStreamStore streamStore = new InMemoryStreamStore(() => GetUtcNow());
             return Task.FromResult(streamStore);
         }
+
+        public override long MinPosition => 0;
     }
 }

--- a/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
+++ b/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>SqlStreamStore.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NoWarn>1701;1702;1705;1591</NoWarn>
+    <RootNamespace>SqlStreamStore</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
+++ b/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectCapability Include="ShowFilesOutsideOfProject" />
-    <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" />
+    <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" LinkBase="InMemory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlStreamStore/Streams/Position.cs
+++ b/src/SqlStreamStore/Streams/Position.cs
@@ -6,6 +6,11 @@
     public static class Position
     {
         /// <summary>
+        ///     No position
+        /// </summary>
+        public static readonly long? None = null;
+
+        /// <summary>
         ///     The start of the store.
         /// </summary>
         public const long Start = 0;

--- a/src/SqlStreamStore/Streams/StreamVersion.cs
+++ b/src/SqlStreamStore/Streams/StreamVersion.cs
@@ -6,12 +6,17 @@
     public static class StreamVersion
     {
         /// <summary>
-        /// The first message in a stream
+        ///     No stream version.
+        /// </summary>
+        public static readonly int? None = null;
+
+        /// <summary>
+        ///     The first message in a stream
         /// </summary>
         public const int Start = 0;
 
         /// <summary>
-        /// The last message in the stream.
+        ///     The last message in the stream.
         /// </summary>
         public const int End = -1;
     }


### PR DESCRIPTION
Position is generally implemented as an identity / sequence / auto-increment in the various stores. The value will always be increasing, but it is not guaranteed to be sequential. That is, there may be gaps.

Also, different stores will start at different positions values. i.e. MS SQL's identity starts at 0 whereas MySQL's auto increment starts at 1. It was discussed to normalize the behavior across all store implementation but was decided against - the position should be opaque to the end user and they should not derive any meaning from it's specific value. (Though they can derive meaning when comparing two values to see which is bigger or if they are equal.)

Each store fixture needs to define the `MinPositon` that is then used in tests. The tests have been updated to use this value as a base to see if the position has increased. Any assertions on a specific value of a position have been removed or altered.