### PR TITLE
Fix Test Reporting

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$CakeVersion = "0.21.1"
+$CakeVersion = "0.22.0"
 $DotNetChannel = "Current";
 $DotNetVersion = "2.0.0";
 $DotNetInstallerUri = "https://dot.net/dotnet-install.ps1";

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
@@ -10,12 +10,12 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests : IDisposable
+    public abstract partial class StreamStoreAcceptanceTests : IDisposable
     {
         private readonly ITestOutputHelper _testOutputHelper;
         private readonly IDisposable _logCapture;
 
-        public StreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper)
+        protected StreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper)
         {
             _testOutputHelper = testOutputHelper;
             _logCapture = CaptureLogs(testOutputHelper);
@@ -25,6 +25,11 @@
         {
             _logCapture.Dispose();
         }
+
+        protected abstract StreamStoreAcceptanceTestFixture GetFixture();
+
+        private static IDisposable CaptureLogs(ITestOutputHelper testOutputHelper) 
+            => LoggingHelper.Capture(testOutputHelper);
 
         [Fact]
         public async Task When_dispose_and_read_then_should_throw()
@@ -70,7 +75,7 @@
                 .ToArray();
         }
 
-        private static NewStreamMessage[] CreateNewStreamMessageSequence(int startId, int count)
+        public static NewStreamMessage[] CreateNewStreamMessageSequence(int startId, int count)
         {
             var messages = new List<NewStreamMessage>();
             for(int i = 0; i < count; i++)
@@ -83,7 +88,7 @@
             return messages.ToArray();
         }
 
-        private static StreamMessage ExpectedStreamMessage(
+        public static StreamMessage ExpectedStreamMessage(
             string streamId,
             int messageNumber,
             int sequenceNumber,

--- a/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreAcceptanceTests.cs
@@ -7,17 +7,15 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests
+    public class MsSqlStreamStoreAcceptanceTests : StreamStoreAcceptanceTests
     {
-        private StreamStoreAcceptanceTestFixture GetFixture(string schema = "foo")
-        {
-            return new MsSqlStreamStoreFixture(schema);
-        }
+        public MsSqlStreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        { }
 
-        private IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
-        {
-            return LoggingHelper.Capture(testOutputHelper);
-        }
+        protected override StreamStoreAcceptanceTestFixture GetFixture()
+            => new MsSqlStreamStoreFixture("foo");
+
 
         [Fact]
         public async Task Can_use_multiple_schemas()

--- a/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
+++ b/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
@@ -29,8 +29,9 @@
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
 </Project>

--- a/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreAcceptanceTests.cs
@@ -7,17 +7,14 @@
     using Xunit;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests
+    public class PostgresStreamStoreAcceptanceTests : StreamStoreAcceptanceTests
     {
-        private StreamStoreAcceptanceTestFixture GetFixture(string schema = "foo")
-        {
-            return new PostgresStreamStoreFixture(schema);
-        }
+        public PostgresStreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        { }
 
-        private IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
-        {
-            return LoggingHelper.Capture(testOutputHelper);
-        }
+        protected override StreamStoreAcceptanceTestFixture GetFixture()
+            => new PostgresStreamStoreFixture("foo");
 
         [Fact]
         public async Task Can_use_multiple_schemas()

--- a/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
+++ b/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
@@ -28,8 +28,9 @@
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
     <PackageReference Include="Npgsql" Version="3.2.5" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlStreamStore.Tests/InMemory/InMemoryStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.Tests/InMemory/InMemoryStreamStoreAcceptanceTests.cs
@@ -1,20 +1,16 @@
 ﻿ // ReSharper disable once CheckNamespace
 namespace SqlStreamStore
 {
-    using System;
     using SqlStreamStore.InMemory;
     using Xunit.Abstractions;
 
-    public partial class StreamStoreAcceptanceTests
+    public class InMemoryStreamStoreAcceptanceTests : StreamStoreAcceptanceTests
     {
-        private StreamStoreAcceptanceTestFixture GetFixture()
-        {
-            return new InMemoryStreamStoreFixture();
-        }
+        public InMemoryStreamStoreAcceptanceTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        { }
 
-        private IDisposable CaptureLogs(ITestOutputHelper testOutputHelper)
-        {
-            return LoggingHelper.Capture(testOutputHelper);
-        }
+        protected override  StreamStoreAcceptanceTestFixture GetFixture()
+            => new InMemoryStreamStoreFixture();
     }
 }

--- a/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
+++ b/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
@@ -23,8 +23,9 @@
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Because the tests are all linked files, they have the same namespace / name, which means that Teamcity cannot differentiate them.

- use inheritance for acceptance tests so each gets a different name in test output
- dotnet xunit test runner
- updates to Cake 0.22 (allows c#6 syntax)