### PR TITLE
Correct the spelling of "create"

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionAny.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionAny.sql
@@ -1,11 +1,11 @@
 DECLARE @streamIdInternal AS INT;
 
-BEGIN TRANSACTION CreatStreamIfNotExists;
+BEGIN TRANSACTION CreateStreamIfNotExists;
     IF NOT EXISTS (SELECT * FROM dbo.Streams WITH (UPDLOCK, ROWLOCK, HOLDLOCK)
                      WHERE dbo.Streams.Id = @streamId)
      INSERT INTO dbo.Streams (Id, IdOriginal) VALUES (@streamId, @streamIdOriginal);
 
-COMMIT TRANSACTION CreatStreamIfNotExists;
+COMMIT TRANSACTION CreateStreamIfNotExists;
 
 BEGIN TRANSACTION AppendStream;
     DECLARE @latestStreamVersion AS INT;

--- a/src/SqlStreamStore/Streams/Deleted.cs
+++ b/src/SqlStreamStore/Streams/Deleted.cs
@@ -24,7 +24,7 @@
         public const string MessageDeletedMessageType = "$message-deleted";
 
         /// <summary>
-        ///     Createts <see cref="NewStreamMessage"/> that contains a stream deleted message.
+        ///     Creates a <see cref="NewStreamMessage"/> that contains a stream deleted message.
         /// </summary>
         /// <param name="streamId">The stream id of the deleted stream.</param>
         /// <returns>A <see cref="NewStreamMessage"/>.</returns>
@@ -37,7 +37,7 @@
         }
 
         /// <summary>
-        ///     Createts a <see cref="NewStreamMessage"/> that contains a message deleted message.
+        ///     Creates a <see cref="NewStreamMessage"/> that contains a message deleted message.
         /// </summary>
         /// <param name="streamId">The stream id of the deleted stream.</param>
         /// <param name="messageId">The message id of the deleted message.</param>


### PR DESCRIPTION
While working through some of the tests, I came across the spelling of create in the scripts as well as the code documentation.