### PR TITLE
Improve MsSql append performance

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersion.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersion.sql
@@ -1,67 +1,53 @@
 BEGIN TRANSACTION AppendStream;
-    DECLARE @streamIdInternal AS INT;
-    DECLARE @latestStreamVersion AS INT;
-	DECLARE @latestStreamPosition AS BIGINT;
+DECLARE @streamIdInternal AS INT;
+DECLARE @latestStreamVersion AS INT;
+DECLARE @latestStreamPosition AS BIGINT;
 
-     SELECT @streamIdInternal = dbo.Streams.IdInternal,
-            @latestStreamVersion = dbo.Streams.[Version]
-       FROM dbo.Streams
-      WHERE dbo.Streams.Id = @streamId;
+SELECT @streamIdInternal = dbo.Streams.IdInternal, @latestStreamVersion = dbo.Streams.[Version]
+FROM dbo.Streams
+WHERE dbo.Streams.Id = @streamId;
 
-         IF @streamIdInternal IS NULL
-        BEGIN
-            ROLLBACK TRANSACTION AppendStream;
-            RAISERROR('WrongExpectedVersion', 16, 1);
-            RETURN;
-        END
+IF @streamIdInternal IS NULL
+    BEGIN
+        ROLLBACK TRANSACTION AppendStream;
+        RAISERROR('WrongExpectedVersion', 16, 1);
+        RETURN;
+    END
+IF @latestStreamVersion != @expectedStreamVersion
+    BEGIN
+        ROLLBACK TRANSACTION AppendStream;
+        RAISERROR('WrongExpectedVersion', 16, 2);
+        RETURN;
+    END
 
-        IF @latestStreamVersion != @expectedStreamVersion
-        BEGIN
-            ROLLBACK TRANSACTION AppendStream;
-            RAISERROR('WrongExpectedVersion', 16, 2);
-            RETURN;
-        END
+INSERT INTO dbo.Messages
+    (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
+    SELECT @streamIdInternal, StreamVersion + @latestStreamVersion + 1, Id, Created, [Type], JsonData, JsonMetadata
+    FROM @newMessages
+    ORDER BY StreamVersion;
 
-INSERT INTO dbo.Messages (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
-     SELECT @streamIdInternal,
-            StreamVersion + @latestStreamVersion + 1,
-            Id,
-            Created,
-            [Type],
-            JsonData,
-            JsonMetadata
-       FROM @newMessages
-   ORDER BY StreamVersion;
+SET @latestStreamPosition = SCOPE_IDENTITY()
 
-  SELECT TOP(1)
-            @latestStreamVersion = dbo.Messages.StreamVersion,
-            @latestStreamPosition = dbo.Messages.Position
-       FROM dbo.Messages
-      WHERE dbo.Messages.StreamIDInternal = @streamIdInternal
-   ORDER BY dbo.Messages.Position DESC
+SELECT @latestStreamVersion = MAX(StreamVersion) + @latestStreamVersion + 1
+FROM @newMessages
 
-     UPDATE dbo.Streams
-        SET dbo.Streams.[Version] = @latestStreamVersion,
-            dbo.Streams.[Position] = @latestStreamPosition
-      WHERE dbo.Streams.IdInternal = @streamIdInternal
+UPDATE dbo.Streams
+    SET dbo.Streams.[Version] = @latestStreamVersion,
+        dbo.Streams.[Position] = @latestStreamPosition
+    WHERE dbo.Streams.IdInternal = @streamIdInternal
 
 COMMIT TRANSACTION AppendStream;
 
 /* Select CurrentVersion, CurrentPosition */
 
-     SELECT currentVersion = @latestStreamVersion, currentPosition = @latestStreamPosition
+SELECT currentVersion = @latestStreamVersion, currentPosition = @latestStreamPosition
 
 /* Select Metadata */
-    DECLARE @metadataStreamId as NVARCHAR(42)
-    DECLARE @metadataStreamIdInternal as INT
-        SET @metadataStreamId = '$$' + @streamId
 
-     SELECT @metadataStreamIdInternal = dbo.Streams.IdInternal
-       FROM dbo.Streams
-      WHERE dbo.Streams.Id = @metadataStreamId;
-
-     SELECT TOP(1)
-            dbo.Messages.JsonData
-       FROM dbo.Messages
-      WHERE dbo.Messages.StreamIdInternal = @metadataStreamIdInternal
-   ORDER BY dbo.Messages.Position DESC;
+SELECT dbo.Messages.JsonData
+FROM dbo.Messages
+WHERE dbo.Messages.Position = (
+    SELECT dbo.Streams.Position
+    FROM dbo.Streams
+    WHERE dbo.Streams.Id = '$$' + @streamId
+)

--- a/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersion.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersion.sql
@@ -1,40 +1,41 @@
 BEGIN TRANSACTION AppendStream;
-DECLARE @streamIdInternal AS INT;
-DECLARE @latestStreamVersion AS INT;
-DECLARE @latestStreamPosition AS BIGINT;
 
-SELECT @streamIdInternal = dbo.Streams.IdInternal, @latestStreamVersion = dbo.Streams.[Version]
-FROM dbo.Streams
-WHERE dbo.Streams.Id = @streamId;
+    DECLARE @streamIdInternal AS INT;
+    DECLARE @latestStreamVersion AS INT;
+    DECLARE @latestStreamPosition AS BIGINT;
 
-IF @streamIdInternal IS NULL
-    BEGIN
-        ROLLBACK TRANSACTION AppendStream;
-        RAISERROR('WrongExpectedVersion', 16, 1);
-        RETURN;
-    END
-IF @latestStreamVersion != @expectedStreamVersion
-    BEGIN
-        ROLLBACK TRANSACTION AppendStream;
-        RAISERROR('WrongExpectedVersion', 16, 2);
-        RETURN;
-    END
+    SELECT @streamIdInternal = dbo.Streams.IdInternal, @latestStreamVersion = dbo.Streams.[Version]
+    FROM dbo.Streams WITH (UPDLOCK, ROWLOCK)
+    WHERE dbo.Streams.Id = @streamId;
 
-INSERT INTO dbo.Messages
-    (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
-    SELECT @streamIdInternal, StreamVersion + @latestStreamVersion + 1, Id, Created, [Type], JsonData, JsonMetadata
+    IF @streamIdInternal IS NULL
+        BEGIN
+            ROLLBACK TRANSACTION AppendStream;
+            RAISERROR('WrongExpectedVersion', 16, 1);
+            RETURN;
+        END
+    IF @latestStreamVersion != @expectedStreamVersion
+        BEGIN
+            ROLLBACK TRANSACTION AppendStream;
+            RAISERROR('WrongExpectedVersion', 16, 2);
+            RETURN;
+        END
+
+    INSERT INTO dbo.Messages
+        (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
+        SELECT @streamIdInternal, StreamVersion + @latestStreamVersion + 1, Id, Created, [Type], JsonData, JsonMetadata
+        FROM @newMessages
+        ORDER BY StreamVersion;
+
+    SET @latestStreamPosition = SCOPE_IDENTITY()
+
+    SELECT @latestStreamVersion = MAX(StreamVersion) + @latestStreamVersion + 1
     FROM @newMessages
-    ORDER BY StreamVersion;
 
-SET @latestStreamPosition = SCOPE_IDENTITY()
-
-SELECT @latestStreamVersion = MAX(StreamVersion) + @latestStreamVersion + 1
-FROM @newMessages
-
-UPDATE dbo.Streams
-    SET dbo.Streams.[Version] = @latestStreamVersion,
-        dbo.Streams.[Position] = @latestStreamPosition
-    WHERE dbo.Streams.IdInternal = @streamIdInternal
+    UPDATE dbo.Streams
+        SET dbo.Streams.[Version] = @latestStreamVersion,
+            dbo.Streams.[Position] = @latestStreamPosition
+        WHERE dbo.Streams.IdInternal = @streamIdInternal
 
 COMMIT TRANSACTION AppendStream;
 

--- a/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionAny.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionAny.sql
@@ -1,64 +1,56 @@
 DECLARE @streamIdInternal AS INT;
 
 BEGIN TRANSACTION CreateStreamIfNotExists;
-    IF NOT EXISTS (SELECT * FROM dbo.Streams WITH (UPDLOCK, ROWLOCK, HOLDLOCK)
-                     WHERE dbo.Streams.Id = @streamId)
-     INSERT INTO dbo.Streams (Id, IdOriginal) VALUES (@streamId, @streamIdOriginal);
+
+    IF NOT EXISTS (
+        SELECT *
+        FROM dbo.Streams WITH (UPDLOCK, ROWLOCK, HOLDLOCK)
+        WHERE dbo.Streams.Id = @streamId
+    )
+        INSERT INTO dbo.Streams (Id, IdOriginal)
+        VALUES (@streamId, @streamIdOriginal);
 
 COMMIT TRANSACTION CreateStreamIfNotExists;
 
 BEGIN TRANSACTION AppendStream;
+
     DECLARE @latestStreamVersion AS INT;
-	DECLARE @latestStreamPosition AS BIGINT;
+    DECLARE @latestStreamPosition AS BIGINT;
 
-     SELECT @streamIdInternal = dbo.Streams.IdInternal,
-            @latestStreamVersion = dbo.Streams.[Version]
-       FROM dbo.Streams WITH (UPDLOCK, ROWLOCK)
-      WHERE dbo.Streams.Id = @streamId;
+    SELECT @streamIdInternal = dbo.Streams.IdInternal, @latestStreamVersion = dbo.Streams.[Version]
+    FROM dbo.Streams WITH (UPDLOCK, ROWLOCK)
+    WHERE dbo.Streams.Id = @streamId;
 
-INSERT INTO dbo.Messages (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
-     SELECT @streamIdInternal,
-            StreamVersion + @latestStreamVersion + 1,
-            Id,
-            Created,
-            [Type],
-            JsonData,
-            JsonMetadata
+    INSERT INTO dbo.Messages
+        (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
+        SELECT @streamIdInternal, StreamVersion + @latestStreamVersion + 1, Id, Created, [Type], JsonData, JsonMetadata
         FROM @newMessages
-    ORDER BY StreamVersion
+        ORDER BY StreamVersion
 
-     SELECT TOP(1)
-            @latestStreamVersion = dbo.Messages.StreamVersion,
-            @latestStreamPosition = dbo.Messages.Position
-       FROM dbo.Messages
-      WHERE dbo.Messages.StreamIDInternal = @streamIdInternal
-   ORDER BY dbo.Messages.Position DESC
+    SET @latestStreamPosition = ISNULL(SCOPE_IDENTITY(), -1)
 
-    IF @latestStreamPosition IS NULL
-    SET @latestStreamPosition = -1
+    SELECT @latestStreamVersion = MAX(StreamVersion) + @latestStreamVersion + 1
+    FROM @newMessages
 
-     UPDATE dbo.Streams
+    SET @latestStreamVersion = ISNULL(@latestStreamVersion, -1)
+
+    UPDATE dbo.Streams
         SET dbo.Streams.[Version] = @latestStreamVersion,
             dbo.Streams.[Position] = @latestStreamPosition
-      WHERE dbo.Streams.IdInternal = @streamIdInternal
+        WHERE dbo.Streams.IdInternal = @streamIdInternal
 
 COMMIT TRANSACTION AppendStream;
 
 /* Select CurrentVersion, CurrentPosition */
 
-    SELECT currentVersion = @latestStreamVersion, currentPosition = @latestStreamPosition
+SELECT currentVersion = @latestStreamVersion, currentPosition = @latestStreamPosition
 
 /* Select Metadata */
-    DECLARE @metadataStreamId as NVARCHAR(42)
-    DECLARE @metadataStreamIdInternal as INT
-        SET @metadataStreamId = '$$' + @streamId
 
-     SELECT @metadataStreamIdInternal = dbo.Streams.IdInternal
-       FROM dbo.Streams
-      WHERE dbo.Streams.Id = @metadataStreamId;
-
-     SELECT TOP(1)
-            dbo.Messages.JsonData
-       FROM dbo.Messages
-      WHERE dbo.Messages.StreamIdInternal = @metadataStreamIdInternal
-   ORDER BY dbo.Messages.Position DESC;
+SELECT dbo.Messages.JsonData
+FROM dbo.Messages
+WHERE dbo.Messages.Position = (
+    SELECT dbo.Streams.Position
+    FROM dbo.Streams
+    WHERE dbo.Streams.Id = '$$' + @streamId
+)

--- a/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionNoStream.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionNoStream.sql
@@ -1,58 +1,50 @@
 BEGIN TRANSACTION CreateStream;
+
     DECLARE @streamIdInternal AS INT;
     DECLARE @latestStreamVersion AS INT;
-	DECLARE @latestStreamPosition AS BIGINT;
+    DECLARE @latestStreamPosition AS BIGINT;
 
     BEGIN
-        INSERT INTO dbo.Streams (Id, IdOriginal) VALUES (@streamId, @streamIdOriginal);
-        SELECT @streamIdInternal = SCOPE_IDENTITY();
 
-            INSERT INTO dbo.Messages (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
-                 SELECT @streamIdInternal,
-                        StreamVersion,
-                        Id,
-                        Created,
-                        [Type],
-                        JsonData,
-                        JsonMetadata
-                   FROM @newMessages
-               ORDER BY StreamVersion;
+        INSERT INTO dbo.Streams
+            (Id, IdOriginal)
+        VALUES
+            (@streamId, @streamIdOriginal);
 
-             SELECT TOP(1)
-                    @latestStreamVersion = dbo.Messages.StreamVersion,
-                    @latestStreamPosition = dbo.Messages.Position
-              FROM dbo.Messages
-             WHERE dbo.Messages.StreamIDInternal = @streamIdInternal
-          ORDER BY dbo.Messages.Position DESC
+        SET @streamIdInternal = SCOPE_IDENTITY();
 
-             IF @latestStreamVersion IS NULL
-            SET @latestStreamVersion = -1
+        INSERT INTO dbo.Messages
+            (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
+            SELECT @streamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata
+            FROM @newMessages
+            ORDER BY StreamVersion;
 
-             IF @latestStreamPosition IS NULL
-            SET @latestStreamPosition = -1
+        SET @latestStreamPosition = ISNULL(SCOPE_IDENTITY(), -1)
 
-            UPDATE dbo.Streams
-               SET dbo.Streams.[Version] = @latestStreamVersion,
-                   dbo.Streams.[Position] = @latestStreamPosition
-             WHERE dbo.Streams.IdInternal = @streamIdInternal
+        SELECT @latestStreamVersion = MAX(StreamVersion) + @latestStreamVersion + 1
+        FROM @newMessages
+
+        SET @latestStreamVersion = ISNULL(@latestStreamVersion, -1)
+
+        UPDATE dbo.Streams
+            SET dbo.Streams.[Version] = @latestStreamVersion,
+                dbo.Streams.[Position] = @latestStreamPosition
+            WHERE dbo.Streams.IdInternal = @streamIdInternal
+
     END;
+
 COMMIT TRANSACTION CreateStream;
 
 /* Select CurrentVersion, CurrentPosition */
 
-     SELECT currentVersion = @latestStreamVersion, currentPosition = @latestStreamPosition
+SELECT currentVersion = @latestStreamVersion, currentPosition = @latestStreamPosition
 
 /* Select Metadata */
-    DECLARE @metadataStreamId as NVARCHAR(42)
-    DECLARE @metadataStreamIdInternal as INT
-        SET @metadataStreamId = '$$' + @streamId
 
-     SELECT @metadataStreamIdInternal = dbo.Streams.IdInternal
-       FROM dbo.Streams
-      WHERE dbo.Streams.Id = @metadataStreamId;
-
-     SELECT TOP(1)
-            dbo.Messages.JsonData
-       FROM dbo.Messages
-      WHERE dbo.Messages.StreamIdInternal = @metadataStreamIdInternal
-   ORDER BY dbo.Messages.Position DESC;
+SELECT dbo.Messages.JsonData
+FROM dbo.Messages
+WHERE dbo.Messages.Position = (
+    SELECT dbo.Streams.Position
+    FROM dbo.Streams
+    WHERE dbo.Streams.Id = '$$' + @streamId
+)

--- a/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionNoStream.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/AppendStreamExpectedVersionNoStream.sql
@@ -21,7 +21,7 @@ BEGIN TRANSACTION CreateStream;
 
         SET @latestStreamPosition = ISNULL(SCOPE_IDENTITY(), -1)
 
-        SELECT @latestStreamVersion = MAX(StreamVersion) + @latestStreamVersion + 1
+        SELECT @latestStreamVersion = MAX(StreamVersion)
         FROM @newMessages
 
         SET @latestStreamVersion = ISNULL(@latestStreamVersion, -1)

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
@@ -139,12 +139,14 @@
                     var sqlDataRecords = CreateSqlDataRecords(messages);
                     var eventsParam = CreateNewMessagesSqlParameter(sqlDataRecords);
                     command.Parameters.Add(eventsParam);
+                    command.Parameters.AddWithValue("hasMessages", true);
                 }
                 else
                 {
                     // Must use a null value for the table-valued param if there are no records
                     var eventsParam = CreateNewMessagesSqlParameter(null);
                     command.Parameters.Add(eventsParam);
+                    command.Parameters.AddWithValue("hasMessages", false);
                 }
 
                 try
@@ -241,12 +243,14 @@
                     var sqlDataRecords = CreateSqlDataRecords(messages);
                     var eventsParam = CreateNewMessagesSqlParameter(sqlDataRecords);
                     command.Parameters.Add(eventsParam);
+                    command.Parameters.AddWithValue("hasMessages", true);
                 }
                 else
                 {
                     // Must use a null value for the table-valued param if there are no records
                     var eventsParam = CreateNewMessagesSqlParameter(null);
                     command.Parameters.Add(eventsParam);
+                    command.Parameters.AddWithValue("hasMessages", false);
                 }
 
                 try


### PR DESCRIPTION
While appending a very large number - in reasonable batches - of events (in our case close to 2 million), to a stream, we noticed a performance degradation over time that manifested itself both on Windows (we used `Microsoft SQL Server 2017 (RTM) - 14.0.1000.169 (X64)`) and Linux (we used `Microsoft SQL Server 2017 (RTM-CU5) (KB4092643) - 14.0.3023.8 (X64)`). Intrigued we started profiling the SQL statements using SQL Profiler. We noticed that the number of reads performed by SQL Server upon each append started to grow the more events were appended. The query execution plan revealed that some of the SQL statements during the append operation were performing _Index Scans_ instead of _Index Seeks_.

For `AppendStreamExpectedVersion.sql` we
- replaced the query for the latest stream position by a SCOPE_IDENTITY() function call yielding the same result but a lot faster, thereby eliminating the use of an index,
- replaced the query for the latest stream version by a computation (which could also be passed in as a parameter - just didn't feel like changing the calling C# code at this point) based on the `new stream messages` table parameter, thereby eliminating the use of an index,
- replaced the query for the latest json data of the metadata stream (if such a stream exists) by a query that uses the latest position of the metadata stream, thereby replacing an index scan by index seek (since `position` is PK of the `messages` table).

The first two changes, which happen within the transaction, do not have a different outcome than the previous version of these SQL statements. The latter change, outside of the transaction, switched from using the sort and top clause to an exact position read which could potentially give you a different result. I doubt this will be a problem since there's no transaction in place to give you any guarantee on the outcome of that query (other than "we think this is the latest message in the metadata stream"). Ultimately, it's being used to feed the code with the `maxcount` of the stream we're appending to.

Timing our own code we saw the following improvement (appending 2 million events to 1 stream in batches of a 1000 events / batch):
- Before: 2.068.175ms
- After: 292.974ms

I performed similar changes for the `AppendStreamExpectedVersionAny.sql` and `AppendStreamExpectedVersionNoStream.sql`.