### PR TITLE
Bug When Reading Stream Backwards

### DIFF
--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
@@ -1,5 +1,6 @@
 ﻿namespace SqlStreamStore
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -376,6 +377,25 @@
                         await store.ReadStreamBackwards("stream-1", StreamVersion.Start, 1);
 
                     streamMessagesPage.Status.ShouldBe(PageReadStatus.StreamNotFound);
+                }
+            }
+        }
+
+        [Theory, InlineData(0), InlineData(1)]
+        public async Task Can_read_stream_backwards_starting_past_end_of_stream(int fromVersionInclusive)
+        {
+            using(var fixture = GetFixture())
+            {
+                using(var store = await fixture.GetStreamStore())
+                {
+                    await store.AppendToStream("stream-1", ExpectedVersion.NoStream, Array.Empty<NewStreamMessage>());
+
+                    var streamMessagesPage =
+                        await store.ReadStreamBackwards("stream-1", fromVersionInclusive, 1);
+
+                    streamMessagesPage.Status.ShouldBe(PageReadStatus.Success);
+                    streamMessagesPage.Messages.Length.ShouldBe(0);
+                    streamMessagesPage.IsEnd.ShouldBeTrue();
                 }
             }
         }

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -589,7 +589,7 @@ namespace SqlStreamStore
 
                 var messages = new List<StreamMessage>();
                 var i = fromVersionInclusive == StreamVersion.End ? stream.Messages.Count - 1 : fromVersionInclusive;
-                while (i >= 0 && count > 0)
+                while (i < stream.Messages.Count && i >= 0 && count > 0)
                 {
                     var inMemorymessage = stream.Messages[i];
                     StreamMessage message;


### PR DESCRIPTION
When you read a stream backwards starting at a version that's beyond the end of the stream, the behavior is different depending on the implementation. Works as expected for MSSQL but throws an `ArgumentOutOfRangeException` for the In Memory implementation.