### PR TITLE
Removing unspecified argument from formatted log.

### DIFF
--- a/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
@@ -67,8 +67,7 @@ namespace SqlStreamStore.Infrastructure
 
             if (Logger.IsDebugEnabled())
             {
-                Logger.DebugFormat("DeleteStream {streamId} with expected version {expectedVersion} and " +
-                                   "{messageCount} messages." , streamId, expectedVersion);
+                Logger.DebugFormat("DeleteStream {streamId} with expected version {expectedVersion}.", streamId, expectedVersion);
             }
 
             return DeleteStreamInternal(streamId, expectedVersion, cancellationToken);


### PR DESCRIPTION
When debug logging is enabled, `StreamStoreBase.DeleteStream()` attempts to log the deletion with `streamId`, `expectedVersion` and `messageCount` as metadata. 

`messageCount` is however not available in the context of the method, thus resulting in an exception being thrown as the log statement can't be formatted.

This pull requests fixes it by removing `messageCount` from the log statement.