### PR TITLE
Handle SetStreamMetadata idempotently

### DIFF
--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -279,5 +279,26 @@
                 }
             }
         }
+
+
+        [Fact, Trait("Category", "StreamMetadata")]
+        public async Task When_set_metadata_with_same_data_then_should_handle_idempotently()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await store
+                        .SetStreamMetadata(streamId, maxCount: 2, maxAge: 30, metadataJson: "meta");
+                    await store
+                        .SetStreamMetadata(streamId, maxCount: 2, maxAge: 30, metadataJson: "meta");
+
+                    var metadata = await store.GetStreamMetadata(streamId);
+
+                    metadata.MetadataStreamVersion.ShouldBe(0);
+                }
+            }
+        }
     }
 }

--- a/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
+++ b/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
@@ -12,9 +12,6 @@
     <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="SqlStreamStore.MsSql.Tests.v3.ncrunchproject" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\SqlStreamStore.MsSql\SqlStreamStore.MsSql.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
@@ -193,6 +193,7 @@
                         false,
                         null,
                         connection,
+                        transaction,
                         cancellationToken)
                         .NotOnCapturedContext();
 
@@ -288,6 +289,7 @@
                                 false,
                                 null,
                                 connection,
+                                transaction,
                                 cancellationToken)
                             .NotOnCapturedContext();
 
@@ -387,6 +389,7 @@
                                 false,
                                 null,
                                 connection,
+                                transaction,
                                 cancellationToken);
 
                             if(messages.Length > page.Messages.Length)

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
@@ -24,7 +24,7 @@
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
                 var streamIdInfo = new StreamIdInfo(streamId);
                 return await ReadStreamInternal(streamIdInfo.SqlStreamId, start, count, ReadDirection.Forward,
-                    prefetch, readNext, connection, cancellationToken);
+                    prefetch, readNext, connection, null, cancellationToken);
             }
         }
 
@@ -41,7 +41,7 @@
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
                 var streamIdInfo = new StreamIdInfo(streamId);
                 return await ReadStreamInternal(streamIdInfo.SqlStreamId, start, count, ReadDirection.Backward,
-                    prefetch, readNext, connection, cancellationToken);
+                    prefetch, readNext, connection, null, cancellationToken);
             }
         }
 
@@ -52,7 +52,9 @@
             ReadDirection direction,
             bool prefetch,
             ReadNextStreamPage readNext,
-            SqlConnection connection, CancellationToken cancellationToken)
+            SqlConnection connection,
+            SqlTransaction transaction,
+            CancellationToken cancellationToken)
         {
             // If the count is int.MaxValue, TSql will see it as a negative number. 
             // Users shouldn't be using int.MaxValue in the first place anyway.
@@ -87,7 +89,7 @@
                 };
             }
 
-            using(var command = new SqlCommand(commandText, connection))
+            using (var command = new SqlCommand(commandText, connection, transaction))
             {
                 command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
                 command.Parameters.AddWithValue("count", count + 1); //Read extra row to see if at end or not

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.StreamMetadata.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.StreamMetadata.cs
@@ -1,6 +1,5 @@
 ﻿namespace SqlStreamStore
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using SqlStreamStore.Streams;
@@ -27,6 +26,7 @@
                     true,
                     null,
                     connection,
+                    null,
                     cancellationToken);
             }
 
@@ -70,14 +70,15 @@
                         MetaJson = metadataJson
                     };
                     var json = SimpleJson.SerializeObject(metadataMessage);
-                    var newmessage = new NewStreamMessage(Guid.NewGuid(), "$stream-metadata", json);
+                    var messageId = MetadataMessageIdGenerator.Create(json);
+                    var message = new NewStreamMessage(messageId, "$stream-metadata", json);
 
                     result = await AppendToStreamInternal(
                         connection,
                         transaction,
                         streamIdInfo.MetadataSqlStreamId,
                         expectedStreamMetadataVersion,
-                        new[] { newmessage },
+                        new[] { message },
                         cancellationToken);
 
                     transaction.Commit();

--- a/src/SqlStreamStore.Tests/Infrastructure/DeterministicGuidGeneratorTests.cs
+++ b/src/SqlStreamStore.Tests/Infrastructure/DeterministicGuidGeneratorTests.cs
@@ -1,0 +1,29 @@
+﻿namespace SqlStreamStore.Infrastructure
+{
+    using System;
+    using Shouldly;
+    using Xunit;
+
+    public class DeterministicGuidGeneratorTests
+    {
+        [Fact]
+        public void Given_same_input_should_generate_same_Guid()
+        {
+            var generator = new DeterministicGuidGenerator(Guid.NewGuid());
+            var guid1 = generator.Create("some-data");
+            var guid2 = generator.Create("some-data");
+
+            guid2.ShouldBe(guid1);
+        }
+
+        [Fact]
+        public void Given_different_input_should_generate_different_Guid()
+        {
+            var generator = new DeterministicGuidGenerator(Guid.NewGuid());
+            var guid1 = generator.Create("some-data");
+            var guid2 = generator.Create("other-data");
+
+            guid2.ShouldNotBe(guid1);
+        }
+    }
+}

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -225,9 +225,10 @@ namespace SqlStreamStore
                     MetaJson = metadataJson
                 };
                 var json = SimpleJson.SerializeObject(metadataMessage);
-                var newmessage = new NewStreamMessage(Guid.NewGuid(), "$stream-metadata", json);
+                var messageId = MetadataMessageIdGenerator.Create(json);
+                var newStreamMessage = new NewStreamMessage(messageId, "$stream-metadata", json);
 
-                var result = AppendToStreamInternal(metaStreamId, expectedStreamMetadataVersion, new[] { newmessage });
+                var result = AppendToStreamInternal(metaStreamId, expectedStreamMetadataVersion, new[] { newStreamMessage });
 
                 await CheckStreamMaxCount(streamId, metadataMessage.MaxCount, cancellationToken);
 

--- a/src/SqlStreamStore/Infrastructure/DeterministicGuidGenerator.cs
+++ b/src/SqlStreamStore/Infrastructure/DeterministicGuidGenerator.cs
@@ -53,14 +53,13 @@
         /// <returns>
         ///     A deterministically generated GUID.
         /// </returns>
-        public Guid Create(IEnumerable<byte> source)
+        public Guid Create(byte[] source)
         {
             byte[] hash;
-            byte[] inputBuffer = source.ToArray();
             using (var algorithm = SHA1.Create())
             {
                 algorithm.TransformBlock(_namespaceBytes, 0, _namespaceBytes.Length, null, 0);
-                algorithm.TransformFinalBlock(inputBuffer, 0, inputBuffer.Length);
+                algorithm.TransformFinalBlock(source, 0, source.Length);
 
                 hash = algorithm.Hash;
             }

--- a/src/SqlStreamStore/Infrastructure/DeterministicGuidGenerator.cs
+++ b/src/SqlStreamStore/Infrastructure/DeterministicGuidGenerator.cs
@@ -1,0 +1,93 @@
+﻿namespace SqlStreamStore.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
+
+    // Adapted from https://github.com/LogosBible/Logos.Utility/blob/master/src/Logos.Utility/GuidUtility.cs
+    // MIT Licence
+
+    /// <summary>
+    ///     A helper utility to generate deterministed GUIDS.
+    /// </summary>
+    public class DeterministicGuidGenerator
+    {
+        private readonly byte[] _namespaceBytes;
+
+        /// <summary>
+        ///     Initializes a new instance of <see cref="DeterministicGuidGenerator"/>
+        /// </summary>
+        /// <param name="guidNameSpace">
+        ///     A namespace that ensures that the GUID generated with this instance
+        ///     do not collided with other generators. Your application should define
+        ///     it's namespace as a constant.
+        /// </param>
+        public DeterministicGuidGenerator(Guid guidNameSpace)
+        {
+            _namespaceBytes = guidNameSpace.ToByteArray();
+            SwapByteOrder(_namespaceBytes);
+        }
+
+        /// <summary>
+        ///     Creates a deterministic GUID.
+        /// </summary>
+        /// <param name="source">
+        ///     A source to generate the GUID from.
+        /// </param>
+        /// <returns>
+        ///     A deterministically generated GUID.
+        /// </returns>
+        public Guid Create(string source)
+        {
+            return Create(Encoding.UTF8.GetBytes(source));
+        }
+
+        /// <summary>
+        ///     Creates a deterministic GUID.
+        /// </summary>
+        /// <param name="source">
+        ///     A source to generate the GUID from.
+        /// </param>
+        /// <returns>
+        ///     A deterministically generated GUID.
+        /// </returns>
+        public Guid Create(IEnumerable<byte> source)
+        {
+            byte[] hash;
+            byte[] inputBuffer = source.ToArray();
+            using (var algorithm = SHA1.Create())
+            {
+                algorithm.TransformBlock(_namespaceBytes, 0, _namespaceBytes.Length, null, 0);
+                algorithm.TransformFinalBlock(inputBuffer, 0, inputBuffer.Length);
+
+                hash = algorithm.Hash;
+            }
+
+            var newGuid = new byte[16];
+            Array.Copy(hash, 0, newGuid, 0, 16);
+
+            newGuid[6] = (byte)((newGuid[6] & 0x0F) | (5 << 4));
+            newGuid[8] = (byte)((newGuid[8] & 0x3F) | 0x80);
+
+            SwapByteOrder(newGuid);
+            return new Guid(newGuid);
+        }
+
+        private static void SwapByteOrder(byte[] guid)
+        {
+            SwapBytes(guid, 0, 3);
+            SwapBytes(guid, 1, 2);
+            SwapBytes(guid, 4, 5);
+            SwapBytes(guid, 6, 7);
+        }
+
+        private static void SwapBytes(byte[] guid, int left, int right)
+        {
+            var temp = guid[left];
+            guid[left] = guid[right];
+            guid[right] = temp;
+        }
+    }
+}

--- a/src/SqlStreamStore/Infrastructure/MetadataMessageIdGenerator.cs
+++ b/src/SqlStreamStore/Infrastructure/MetadataMessageIdGenerator.cs
@@ -1,0 +1,32 @@
+﻿namespace SqlStreamStore.Infrastructure
+{
+    using System;
+
+    /// <summary>
+    ///     A deterministic GUID generator for metadata messages.
+    /// </summary>
+    public static class MetadataMessageIdGenerator
+    {
+        private static readonly DeterministicGuidGenerator s_deterministicGuidGenerator;
+
+        static MetadataMessageIdGenerator()
+        {
+            s_deterministicGuidGenerator 
+                = new DeterministicGuidGenerator(Guid.Parse("8D1E0B02-0D78-408E-8211-F899BE6F8AA2"));
+        }
+
+        /// <summary>
+        ///     Create a GUID for metadata message Ids.
+        /// </summary>
+        /// <param name="message">
+        ///     The metadata message uses as input into the generation algorithim.
+        /// </param>
+        /// <returns>
+        ///     A deterministically generated GUID.
+        /// </returns>
+        public static Guid Create(string message)
+        {
+            return s_deterministicGuidGenerator.Create(message);
+        }
+    }
+}


### PR DESCRIPTION
In many cases a developer will lazily set the metadata of a stream. There are scenarios, especially when appending with StreamVersion.Any that they may set the same metadata over and over. This will increase the metadata stream length unnecessarily.

In another case, if users want to handling this idempotently, they have to invoke a read'n'check first. This has subtle race conditions.

This PR:
 - Adds a deterministic guid generator and tests
 - Add a `MetadataMessageIdGenerator` with a fixed GUID namespace.