### PR TITLE
Allows setting of $deleted stream's metadata

### DIFF
--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -300,5 +300,26 @@
                 }
             }
         }
+
+        [Fact]
+        public async Task Can_set_deleted_stream_metadata()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = Deleted.DeletedStreamId;
+                    await store
+                        .SetStreamMetadata(streamId, maxCount: 2, maxAge: 30);
+
+                    var metadata = await store.GetStreamMetadata(streamId);
+
+                    metadata.MetadataStreamVersion.ShouldBe(0);
+                    metadata.MaxAge.ShouldBe(30);
+                    metadata.MaxCount.ShouldBe(2);
+                    metadata.MetadataJson.ShouldBeNull();
+                }
+            }
+        }
     }
 }

--- a/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
@@ -208,7 +208,11 @@ namespace SqlStreamStore.Infrastructure
            string streamId,
            CancellationToken cancellationToken = default)
         {
-            Ensure.That(streamId, nameof(streamId)).IsNotNullOrWhiteSpace().DoesNotStartWith("$");
+            if (streamId == null) throw new ArgumentNullException(nameof(streamId));
+            if (streamId.StartsWith("$") && streamId != Deleted.DeletedStreamId)
+            {
+                throw new ArgumentException("Must not start with '$'", nameof(streamId));
+            }
 
             if (Logger.IsDebugEnabled())
             {

--- a/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
@@ -98,7 +98,12 @@ namespace SqlStreamStore.Infrastructure
             string metadataJson = null,
             CancellationToken cancellationToken = default)
         {
-            Ensure.That(streamId.Value, nameof(streamId)).DoesNotStartWith("$");
+            if(streamId == null) throw new ArgumentNullException(nameof(streamId));
+            if(streamId.Value.StartsWith("$") && streamId.Value != Deleted.DeletedStreamId)
+            {
+                throw new ArgumentException("Must not start with '$'", nameof(streamId));
+            }
+
             Ensure.That(expectedStreamMetadataVersion, nameof(expectedStreamMetadataVersion)).IsGte(-2);
 
             if (Logger.IsDebugEnabled())


### PR DESCRIPTION
Allows settings the metadata (maxAge / maxCount) for `$deleted` stream via standard API.

Fixes #130 .

