### PR TITLE
Subscriptions: ensure hasCaughtUp is raied with an empty store.

### DIFF
--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -138,7 +138,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using(store.SubscribeToAll(
                         Position.None,
-                        (_, message) =>
+                        (_, message, __) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} " +
                                                         $"{message.StreamVersion} {message.Position}");
@@ -173,7 +173,7 @@
                     var done = new TaskCompletionSource<IAllStreamSubscription>();
                     using (var subscription = store.SubscribeToAll(
                         Position.None,
-                        (sub, _) =>
+                        (sub, _, __) =>
                         {
                             done.SetResult(sub);
                             return Task.CompletedTask;
@@ -202,7 +202,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (store.SubscribeToAll(
                         Position.None,
-                        (_, message) =>
+                        (_, message, __) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} {message.StreamVersion} {message.Position}");
                             receivedMessages.Add(message);
@@ -295,7 +295,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using(var subscription = store.SubscribeToAll(
                         Position.End,
-                        (_, message) =>
+                        (_, message, __) =>
                         {
                             _testOutputHelper.WriteLine($"StreamId={message.StreamId} Version={message.StreamVersion} "
                                                         + $"Position={message.Position}");
@@ -331,7 +331,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (var subscription = store.SubscribeToAll(
                         Position.End,
-                        (_, message) =>
+                        (_, message, __) =>
                         {
                             receivedMessages.Add(message);
                             if (message.StreamId == streamId1 && message.StreamVersion == 9)
@@ -414,7 +414,7 @@
                     var subscriptions = Enumerable.Range(0, subscriptionCount)
                         .Select(index => store.SubscribeToAll(
                             Position.None,
-                            (_, message) =>
+                            (_, message, __) =>
                             {
                                 if(message.StreamVersion == 1)
                                 {
@@ -498,7 +498,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (var subscription = store.SubscribeToAll(
                         Position.None,
-                        (_, message) =>
+                        (_, message, __) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} " +
                                                         $"{message.StreamVersion} {message.Position}");
@@ -669,7 +669,7 @@
                 using (var store = await fixture.GetStreamStore())
                 {
                     var eventReceivedException = new TaskCompletionSource<SubscriptionDroppedReason>();
-                    Task MessageReceived(IAllStreamSubscription _, StreamMessage __) => throw new Exception();
+                    Task MessageReceived(IAllStreamSubscription _, StreamMessage __, CancellationToken ___) => throw new Exception();
                     void SubscriptionDropped(IAllStreamSubscription _, SubscriptionDroppedReason reason, Exception __) => eventReceivedException.SetResult(reason);
                     var streamId = "stream-1";
 
@@ -701,7 +701,7 @@
                     var tcs = new TaskCompletionSource<SubscriptionDroppedReason>();
                     var subscription = store.SubscribeToAll(
                         Position.End,
-                        (_, __) => Task.CompletedTask,
+                        (_, __, ___) => Task.CompletedTask,
                         (_, reason, __) =>
                         {
                             tcs.SetResult(reason);
@@ -724,7 +724,7 @@
                     var tcs = new TaskCompletionSource<IAllStreamSubscription>();
                     var subscription = store.SubscribeToAll(
                         Position.End,
-                        (_, __) => Task.CompletedTask,
+                        (_, __, ___) => Task.CompletedTask,
                         (sub, _, __) =>
                         {
                             tcs.SetResult(sub);
@@ -749,7 +749,7 @@
                     var handler = new AsyncAutoResetEvent();
                     var subscription = store.SubscribeToAll(
                         Position.End,
-                        async (_, __) =>
+                        async (_, __, ___) =>
                         {
                             handler.Set();
                             await handler.WaitAsync().WithTimeout(); // block "handling" while a dispose occurs
@@ -782,7 +782,7 @@
                     var streamId = "stream-1";
                     var subscription = store.SubscribeToAll(
                         Position.Start,
-                        (_, __) => Task.CompletedTask);
+                        (_, __, ___) => Task.CompletedTask);
                     await AppendMessages(store, streamId, 2);
                     subscription.Dispose();
                     subscription.Dispose();
@@ -802,7 +802,7 @@
                     var caughtUp = new TaskCompletionSource<bool>();
                     var subscription = store.SubscribeToAll(
                         Position.None,
-                        (_, __) => Task.CompletedTask,
+                        (_, __, ___) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
                             if(b)
@@ -830,7 +830,7 @@
                     var numberOfCaughtUps = 0;
                     var subscription = store.SubscribeToAll(
                         Position.None,
-                        (_, __) => Task.CompletedTask,
+                        (_, __, ___) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
                             if(b)
@@ -894,7 +894,7 @@
 
                     var subscription = store.SubscribeToAll(
                         Position.None,
-                        (_, __) => Task.CompletedTask,
+                        (_, __, ___) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
                             if (b)
@@ -982,7 +982,7 @@
                 var subscriptionDropped = new TaskCompletionSource<SubscriptionDroppedReason>();
                 var subscription = store.SubscribeToAll(
                     Position.None,
-                    (_, __) => Task.CompletedTask,
+                    (_, __, ___) => Task.CompletedTask,
                     subscriptionDropped: (streamSubscription, reason, exception) =>
                     {
                         subscriptionDropped.SetResult(reason);

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -1037,7 +1037,30 @@
             }
         }
 
-        private static async Task AppendMessages(IStreamStore streamStore, string streamId, int numberOfEvents)
+        [Fact, Trait("Category", "Subscriptions")]
+        public async Task When_subsribe_to_empty_store()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    bool hasCaughtUp = false;
+                    using (store.SubscribeToAll(
+                        null,
+                        (_, message, ct) => Task.CompletedTask,
+                        hasCaughtUp: b => hasCaughtUp = b))
+                    {
+                        await Task.Delay(2000);
+                    }
+                    hasCaughtUp.ShouldBeTrue();
+                }
+            }
+        }
+
+        private static async Task AppendMessages(
+            IStreamStore streamStore,
+            string streamId,
+            int numberOfEvents)
         {
             for(int i = 0; i < numberOfEvents; i++)
             {

--- a/src/SqlStreamStore/Subscriptions/AllStreamMessageReceived.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamMessageReceived.cs
@@ -1,5 +1,6 @@
 ﻿namespace SqlStreamStore.Subscriptions
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using SqlStreamStore.Streams;
 
@@ -10,7 +11,14 @@
     ///      The source subscription.
     /// </param>
     /// <param name="streamMessage">
-    ///     The stream message.</param>
+    ///     The stream message.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///     The cancellation instruction.
+    /// </param>
     /// <returns>A task that represents the asynchronous handling of the stream message.</returns>
-    public delegate Task AllStreamMessageReceived(IAllStreamSubscription subscription, StreamMessage streamMessage);
+    public delegate Task AllStreamMessageReceived(
+        IAllStreamSubscription subscription,
+        StreamMessage streamMessage,
+        CancellationToken cancellationToken);
 }

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -118,7 +118,9 @@
 
                     await Push(page);
 
-                    if ((!lastHasCaughtUp.HasValue || lastHasCaughtUp.Value != page.IsEnd) && page.Messages.Length > 0)
+                    if ((!lastHasCaughtUp.HasValue && page.IsEnd) ||
+                       ((!lastHasCaughtUp.HasValue || lastHasCaughtUp.Value != page.IsEnd)
+                       && page.Messages.Length > 0))
                     {
                         // Only raise if the state changes and there were messages read
                         lastHasCaughtUp = page.IsEnd;

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -215,7 +215,7 @@
                 LastPosition = message.Position;
                 try
                 {
-                    await _streamMessageReceived(this, message).NotOnCapturedContext();
+                    await _streamMessageReceived(this, message, _disposed.Token).NotOnCapturedContext();
                 }
                 catch (Exception ex)
                 {

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -8,7 +8,6 @@
     using SqlStreamStore.Logging;
     using SqlStreamStore.Streams;
 
-
     /// <summary>
     ///     Represents a subscription to a stream.
     /// </summary>

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -129,14 +129,10 @@
                 {
                     var page = await Pull();
 
-                    if (page.Status != PageReadStatus.Success)
-                    {
-                        break;
-                    }
-
                     await Push(page);
 
-                    if (!lastHasCaughtUp.HasValue || lastHasCaughtUp.Value != page.IsEnd)
+                    if ((!lastHasCaughtUp.HasValue && page.IsEnd) ||
+                        ((!lastHasCaughtUp.HasValue || lastHasCaughtUp.Value != page.IsEnd)))
                     {
                         // Only raise if the state changes
                         lastHasCaughtUp = page.IsEnd;


### PR DESCRIPTION
Works for both of AllStreamSubscription and StreamSubscription