### PR TITLE
Improve performance of reading long streams

### DIFF
--- a/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamBackward.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamBackward.sql
@@ -3,12 +3,24 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @lastStreamVersion AS INT
 	DECLARE @lastStreamPosition AS BIGINT
+    DECLARE @position AS BIGINT
 
      SELECT @streamIdInternal = dbo.Streams.IdInternal, @lastStreamVersion = dbo.Streams.[Version], @lastStreamPosition = dbo.Streams.[Position]
        FROM dbo.Streams
       WHERE dbo.Streams.Id = @streamId
 
      SELECT @lastStreamVersion, @lastStreamPosition
+
+     SELECT @position = dbo.Messages.Position
+       FROM dbo.Messages 
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion = @streamVersion
+    
+    IF (@position IS NULL)
+        BEGIN
+            SELECT @position = MAX(dbo.Messages.Position)
+              FROM dbo.Messages 
+             WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion <= @streamVersion
+        END
 
      SELECT TOP(@count)
             dbo.Messages.StreamVersion,
@@ -18,7 +30,5 @@
             dbo.Messages.Type,
             dbo.Messages.JsonMetadata
        FROM dbo.Messages
- INNER JOIN dbo.Streams
-         ON dbo.Messages.StreamIdInternal = dbo.Streams.IdInternal
-      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion <= @streamVersion
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.Position <= @position
    ORDER BY dbo.Messages.Position DESC

--- a/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamBackwardWithData.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamBackwardWithData.sql
@@ -3,12 +3,24 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @lastStreamVersion AS INT
 	DECLARE @lastStreamPosition AS BIGINT
+    DECLARE @position AS BIGINT
 
      SELECT @streamIdInternal = dbo.Streams.IdInternal, @lastStreamVersion = dbo.Streams.[Version], @lastStreamPosition = dbo.Streams.[Position]
        FROM dbo.Streams
       WHERE dbo.Streams.Id = @streamId
 
      SELECT @lastStreamVersion, @lastStreamPosition
+
+     SELECT @position = dbo.Messages.Position
+       FROM dbo.Messages 
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion = @streamVersion
+    
+    IF (@position IS NULL)
+        BEGIN
+            SELECT @position = MAX(dbo.Messages.Position)
+              FROM dbo.Messages 
+             WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion <= @streamVersion
+        END
 
      SELECT TOP(@count)
             dbo.Messages.StreamVersion,
@@ -19,7 +31,5 @@
             dbo.Messages.JsonMetadata,
             dbo.Messages.JsonData
        FROM dbo.Messages
- INNER JOIN dbo.Streams
-         ON dbo.Messages.StreamIdInternal = dbo.Streams.IdInternal
-      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion <= @streamVersion
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.Position <= @position
    ORDER BY dbo.Messages.Position DESC

--- a/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamForward.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamForward.sql
@@ -3,12 +3,24 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @lastStreamVersion AS INT
 	DECLARE @lastStreamPosition AS BIGINT
+    DECLARE @position AS BIGINT
 
      SELECT @streamIdInternal = dbo.Streams.IdInternal, @lastStreamVersion = dbo.Streams.[Version], @lastStreamPosition = dbo.Streams.[Position]
        FROM dbo.Streams
       WHERE dbo.Streams.Id = @streamId
 
      SELECT @lastStreamVersion, @lastStreamPosition
+    
+     SELECT @position = dbo.Messages.Position
+       FROM dbo.Messages 
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion = @streamVersion
+    
+    IF (@position IS NULL)
+        BEGIN
+            SELECT @position = MIN(dbo.Messages.Position)
+              FROM dbo.Messages 
+             WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+        END
 
      SELECT TOP(@count)
             dbo.Messages.StreamVersion,
@@ -18,7 +30,5 @@
             dbo.Messages.Type,
             dbo.Messages.JsonMetadata
        FROM dbo.Messages
- INNER JOIN dbo.Streams
-         ON dbo.Messages.StreamIdInternal = dbo.Streams.IdInternal
-      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.Position >= @position
    ORDER BY dbo.Messages.Position;

--- a/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamForwardWithData.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamForwardWithData.sql
@@ -3,12 +3,24 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @lastStreamVersion AS INT
 	DECLARE @lastStreamPosition AS BIGINT
+    DECLARE @position AS BIGINT
 
      SELECT @streamIdInternal = dbo.Streams.IdInternal, @lastStreamVersion = dbo.Streams.[Version], @lastStreamPosition = dbo.Streams.[Position]
        FROM dbo.Streams
       WHERE dbo.Streams.Id = @streamId
 
      SELECT @lastStreamVersion, @lastStreamPosition
+
+     SELECT @position = dbo.Messages.Position
+       FROM dbo.Messages 
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion = @streamVersion
+    
+    IF (@position IS NULL)
+        BEGIN
+            SELECT @position = MIN(dbo.Messages.Position)
+              FROM dbo.Messages 
+             WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+        END
 
      SELECT TOP(@count)
             dbo.Messages.StreamVersion,
@@ -19,7 +31,5 @@
             dbo.Messages.JsonMetadata,
             dbo.Messages.JsonData
        FROM dbo.Messages
- INNER JOIN dbo.Streams
-         ON dbo.Messages.StreamIdInternal = dbo.Streams.IdInternal
-      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.Position >= @position
    ORDER BY dbo.Messages.Position;

--- a/src/SqlStreamStore.MsSql/ScriptsV3/CreateSchema.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/CreateSchema.sql
@@ -39,17 +39,9 @@ BEGIN
         [Type]              NVARCHAR(128)                           NOT NULL,
         JsonData            NVARCHAR(max)                           NOT NULL,
         JsonMetadata        NVARCHAR(max)                                   ,
-        CONSTRAINT PK_Events PRIMARY KEY NONCLUSTERED (Position),
+        CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (Position),
         CONSTRAINT FK_Events_Streams FOREIGN KEY (StreamIdInternal) REFERENCES dbo.Streams(IdInternal)
     );
-END
-
-IF NOT EXISTS(
-    SELECT * 
-    FROM sys.indexes
-    WHERE name='IX_Messages_Position' AND object_id = OBJECT_ID('dbo.Messages'))
-BEGIN
-    CREATE UNIQUE NONCLUSTERED INDEX IX_Messages_Position ON dbo.Messages (Position);
 END
 
 IF NOT EXISTS(

--- a/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamBackwardWithData.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamBackwardWithData.sql
@@ -1,8 +1,9 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @lastStreamVersion AS INT
     DECLARE @lastStreamPosition AS BIGINT
-    DECLARE @maxAge as INT
-    DECLARE @maxCount as INT
+    DECLARE @maxAge AS INT
+    DECLARE @maxCount AS INT
+    DECLARE @position AS BIGINT
 
      SELECT @streamIdInternal = dbo.Streams.IdInternal,
             @lastStreamVersion = dbo.Streams.[Version],
@@ -17,6 +18,17 @@
             @maxAge,
             @maxCount
 
+     SELECT @position = dbo.Messages.Position
+       FROM dbo.Messages 
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion = @streamVersion
+    
+    IF (@position IS NULL)
+        BEGIN
+            SELECT @position = MAX(dbo.Messages.Position)
+              FROM dbo.Messages 
+             WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion <= @streamVersion
+        END
+
      SELECT TOP(@count)
             dbo.Messages.StreamVersion,
             dbo.Messages.Position,
@@ -26,5 +38,5 @@
             dbo.Messages.JsonMetadata,
             dbo.Messages.JsonData
        FROM dbo.Messages
-      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion <= @streamVersion
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.Position <= @position
    ORDER BY dbo.Messages.Position DESC

--- a/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamForward.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamForward.sql
@@ -1,8 +1,9 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @lastStreamVersion AS INT
     DECLARE @lastStreamPosition AS BIGINT
-    DECLARE @maxAge as INT
-    DECLARE @maxCount as INT
+    DECLARE @maxAge AS INT
+    DECLARE @maxCount AS INT
+    DECLARE @position AS BIGINT
 
      SELECT @streamIdInternal = dbo.Streams.IdInternal,
             @lastStreamVersion = dbo.Streams.[Version],
@@ -17,6 +18,17 @@
             @maxAge,
             @maxCount
 
+     SELECT @position = dbo.Messages.Position
+       FROM dbo.Messages 
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion = @streamVersion
+    
+    IF (@position IS NULL)
+        BEGIN
+            SELECT @position = MIN(dbo.Messages.Position)
+              FROM dbo.Messages 
+             WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+        END
+
      SELECT TOP(@count)
             dbo.Messages.StreamVersion,
             dbo.Messages.Position,
@@ -25,5 +37,5 @@
             dbo.Messages.[Type],
             dbo.Messages.JsonMetadata
        FROM dbo.Messages
-      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.Position >= @position
    ORDER BY dbo.Messages.Position;

--- a/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamForwardWithData.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamForwardWithData.sql
@@ -3,8 +3,9 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @lastStreamVersion AS INT
     DECLARE @lastStreamPosition AS BIGINT
-    DECLARE @maxAge as INT
-    DECLARE @maxCount as INT
+    DECLARE @maxAge AS INT
+    DECLARE @maxCount AS INT
+    DECLARE @position AS BIGINT
 
      SELECT @streamIdInternal = dbo.Streams.IdInternal,
             @lastStreamVersion = dbo.Streams.[Version],
@@ -19,6 +20,17 @@
             @maxAge,
             @maxCount
 
+     SELECT @position = dbo.Messages.Position
+       FROM dbo.Messages 
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion = @streamVersion
+    
+    IF (@position IS NULL)
+        BEGIN
+            SELECT @position = MIN(dbo.Messages.Position)
+              FROM dbo.Messages 
+             WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+        END
+
      SELECT TOP(@count)
             dbo.Messages.StreamVersion,
             dbo.Messages.Position,
@@ -28,5 +40,5 @@
             dbo.Messages.JsonMetadata,
             dbo.Messages.JsonData
        FROM dbo.Messages
-      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.StreamVersion >= @streamVersion
+      WHERE dbo.Messages.StreamIdInternal = @streamIdInternal AND dbo.Messages.Position >= @position
    ORDER BY dbo.Messages.Position;


### PR DESCRIPTION
After having fixed the append performance of long streams in the MsSql provider, it was time to assess the read performance of long streams. I noticed that reading forward started to slow down the further we were reading into the stream. Profiling revealed that an index scan was being performed that did an increasing number of reads the further we read. Tuning the SQL to use an index seek, and a fallback to index scan (in case messages are deleted from said stream during the reading operation), has improved the performance drastically (i.e. from around 30 minutes to around 5 minutes when reading around 2 million events in 1 stream as pages of a 1000 events each).

This PR changes the SQL scripts for reading streams of both the V2 and V3 of the schema - the database schema remains unchanged (except for the change below).

In addition, as per @thefringeninja 's suggestion, we've favoured using a clustered primary key (Position) on the Messages table and dropped the need for keeping track of an additional index on Position. This does change the V3 database schema!