### PR TITLE
Fix NRE with system clock

### DIFF
--- a/src/SqlStreamStore.Http/HttpClientSqlStreamStoreSettings.cs
+++ b/src/SqlStreamStore.Http/HttpClientSqlStreamStoreSettings.cs
@@ -21,26 +21,10 @@
             store => new PollingStreamStoreNotifier(store);
 
         /// <summary>
-        ///     To help with perf, the max age of messages in a stream
-        ///     are cached. It is not expected that a streams max age
-        ///     metadata to be changed frequently. Here we hold on to the
-        ///     max age for the specified timespan. The default is 1 minute.
-        /// </summary>
-        public TimeSpan MetadataMaxAgeCacheExpire { get; set; } = TimeSpan.FromMinutes(1);
-
-        /// <summary>
-        ///     To help with perf, the max age of messages in a stream
-        ///     are cached. It is not expected that a streams max age
-        ///     metadata to be changed frequently. Here we define how many
-        ///     items are cached. The default value is 10000.
-        /// </summary>
-        public int MetadataMaxAgeCacheMaxSize { get; set; } = 10000;
-
-        /// <summary>
         ///     A delegate to return the current UTC now. Used in testing to
         ///     control timestamps and time related operations.
         /// </summary>
-        public GetUtcNow GetUtcNow { get; set; }
+        public GetUtcNow GetUtcNow { get; set; } = SystemClock.GetUtcNow;
 
         /// <summary>
         ///     The log name used for the any log messages.

--- a/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreFixture.cs
+++ b/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreFixture.cs
@@ -103,7 +103,7 @@ namespace SqlStreamStore
             _databaseManager?.Dispose();
         }
 
-        private Task CreateDatabase() => _databaseManager.CreateDatabase();
+        public Task CreateDatabase() => _databaseManager.CreateDatabase();
 
         private interface IDatabaseManager : IDisposable
         {

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
@@ -14,6 +14,10 @@ DECLARE
   _stream_id_internal INT;
   _success            INT;
 BEGIN
+  IF _created_utc IS NULL THEN
+    _created_utc = now() at time zone 'utc';
+  END IF;
+
   IF _expected_version = -2 /* ExpectedVersion.Any */
   THEN
 

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStream.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStream.sql
@@ -12,6 +12,9 @@ DECLARE
   _latest_stream_version INT;
   _affected              INT;
 BEGIN
+  IF _created_utc IS NULL THEN
+    _created_utc = now() at time zone 'utc';
+  END IF;
   SELECT __schema__.streams.id_internal
       INTO _stream_id_internal
   FROM __schema__.streams

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStreamMessages.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStreamMessages.sql
@@ -12,6 +12,9 @@ DECLARE
   _stream_id_internal INT;
   _deleted_count      NUMERIC;
 BEGIN
+  IF _created_utc IS NULL THEN
+    _created_utc = now() at time zone 'utc';
+  END IF;
 
   SELECT __schema__.streams.id_internal
       INTO _stream_id_internal

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/Parameters.cs
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/Parameters.cs
@@ -96,13 +96,19 @@
             };
         }
 
-        public static NpgsqlParameter CreatedUtc(DateTime value)
+        public static NpgsqlParameter CreatedUtc(DateTime? value)
         {
-            return new NpgsqlParameter<DateTime>
-            {
-                TypedValue = value,
-                NpgsqlDbType = NpgsqlDbType.Timestamp
-            };
+            return value.HasValue
+                ? (NpgsqlParameter) new NpgsqlParameter<DateTime>
+                {
+                    TypedValue = value.Value,
+                    NpgsqlDbType = NpgsqlDbType.Timestamp
+                }
+                : new NpgsqlParameter<DBNull>
+                {
+                    TypedValue = DBNull.Value,
+                    NpgsqlDbType = NpgsqlDbType.Timestamp
+                };
         }
 
         public static NpgsqlParameter NewStreamMessages(NewStreamMessage[] value)

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/SetStreamMetadata.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/SetStreamMetadata.sql
@@ -13,6 +13,9 @@ DECLARE
   _current_version INT;
   _stream_updated  INT;
 BEGIN
+  IF _created_utc IS NULL THEN
+    _created_utc = now() at time zone 'utc';
+  END IF;
 
   SELECT current_version
   FROM __schema__.append_to_stream(

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.Append.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.Append.cs
@@ -36,7 +36,7 @@
                         Parameters.StreamId(streamIdInfo.PostgresqlStreamId),
                         Parameters.StreamIdOriginal(streamIdInfo.PostgresqlStreamId),
                         Parameters.ExpectedVersion(expectedVersion),
-                        Parameters.CreatedUtc(_settings.GetUtcNow()),
+                        Parameters.CreatedUtc(_settings.GetUtcNow?.Invoke()),
                         Parameters.NewStreamMessages(messages)))
                     {
                         try

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.Delete.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.Delete.cs
@@ -47,7 +47,7 @@
                 transaction,
                 Parameters.StreamId(streamId),
                 Parameters.ExpectedVersion(expectedVersion),
-                Parameters.CreatedUtc(_settings.GetUtcNow()),
+                Parameters.CreatedUtc(_settings.GetUtcNow?.Invoke()),
                 Parameters.DeletedStreamId,
                 Parameters.DeletedStreamIdOriginal,
                 Parameters.DeletedStreamMessage(streamId)))
@@ -98,7 +98,7 @@
                 Parameters.MessageIds(eventIds),
                 Parameters.DeletedStreamId,
                 Parameters.DeletedStreamIdOriginal,
-                Parameters.CreatedUtc(_settings.GetUtcNow()),
+                Parameters.CreatedUtc(_settings.GetUtcNow?.Invoke()),
                 Parameters.DeletedMessages(streamIdInfo.PostgresqlStreamId, eventIds)))
             {
                 await command.ExecuteNonQueryAsync(cancellationToken).NotOnCapturedContext();

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.Metadata.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.Metadata.cs
@@ -84,7 +84,7 @@
                 Parameters.OptionalMaxAge(metadata.MaxAge),
                 Parameters.OptionalMaxCount(metadata.MaxCount),
                 Parameters.ExpectedVersion(expectedStreamMetadataVersion),
-                Parameters.CreatedUtc(_settings.GetUtcNow()),
+                Parameters.CreatedUtc(_settings.GetUtcNow?.Invoke()),
                 Parameters.MetadataStreamMessage(
                     streamIdInfo.MetadataPosgresqlStreamId, 
                     expectedStreamMetadataVersion, 

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
@@ -27,7 +27,7 @@
             _createConnection = () => _settings.ConnectionFactory(_settings.ConnectionString);
             _streamStoreNotifier = new Lazy<IStreamStoreNotifier>(() =>
             {
-                if(settings.CreateStreamStoreNotifier == null)
+                if(_settings.CreateStreamStoreNotifier == null)
                 {
                     throw new InvalidOperationException(
                         "Cannot create notifier because supplied createStreamStoreNotifier was null");

--- a/src/SqlStreamStore.Postgres/PostgresStreamStoreSettings.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStoreSettings.cs
@@ -57,7 +57,7 @@
         ///     A delegate to return the current UTC now. Used in testing to
         ///     control timestamps and time related operations.
         /// </summary>
-        public GetUtcNow GetUtcNow { get; set; }
+        public GetUtcNow GetUtcNow { get; set; } = SystemClock.GetUtcNow;
 
         /// <summary>
         ///     The log name used for any of the log messages.

--- a/src/SqlStreamStore.Postgres/PostgresStreamStoreSettings.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStoreSettings.cs
@@ -57,7 +57,7 @@
         ///     A delegate to return the current UTC now. Used in testing to
         ///     control timestamps and time related operations.
         /// </summary>
-        public GetUtcNow GetUtcNow { get; set; } = SystemClock.GetUtcNow;
+        public GetUtcNow GetUtcNow { get; set; }
 
         /// <summary>
         ///     The log name used for any of the log messages.


### PR DESCRIPTION
The tests would always supply a GetUtcNow for postgres / http client, but of course the end user may not.

For #150