### PR TITLE
Append to empty stream and lift metadata after a stream is created (if metadata has already been set)

### DIFF
--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
@@ -425,7 +425,7 @@
                     const string streamId = "stream-1";
                     await store.AppendToStream(streamId, ExpectedVersion.NoStream, new NewStreamMessage[0]);
 
-                    var result = await store.AppendToStream(streamId, -1, CreateNewStreamMessages(1, 2, 3));
+                    var result = await store.AppendToStream(streamId, ExpectedVersion.EmptyStream, CreateNewStreamMessages(1, 2, 3));
 
                     result.CurrentVersion.ShouldBe(2);
                 }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
@@ -425,9 +425,9 @@
                     const string streamId = "stream-1";
                     await store.AppendToStream(streamId, ExpectedVersion.NoStream, new NewStreamMessage[0]);
 
-                    var result = await store.AppendToStream(streamId, -1, CreateNewStreamMessages(4));
+                    var result = await store.AppendToStream(streamId, -1, CreateNewStreamMessages(1, 2, 3));
 
-                    result.CurrentVersion.ShouldBe(3);
+                    result.CurrentVersion.ShouldBe(2);
                 }
             }
         }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
@@ -416,6 +416,23 @@
         }
 
         [Fact, Trait("Category", "AppendStream")]
+        public async Task Can_append_to_empty_stream()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await store.AppendToStream(streamId, ExpectedVersion.NoStream, new NewStreamMessage[0]);
+
+                    var result = await store.AppendToStream(streamId, -1, CreateNewStreamMessages(4));
+
+                    result.CurrentVersion.ShouldBe(3);
+                }
+            }
+        }
+
+        [Fact, Trait("Category", "AppendStream")]
         public async Task When_append_stream_second_time_with_expected_version_any_and_all_messages_committed_then_should_be_idempotent_first_message()
         {
             using (var fixture = GetFixture())

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
@@ -399,6 +399,23 @@
         }
 
         [Fact, Trait("Category", "AppendStream")]
+        public async Task Can_create_empty_stream()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await store.AppendToStream(streamId, ExpectedVersion.NoStream, new NewStreamMessage[0]);
+
+                    var page = await store.ReadStreamForwards(streamId, StreamVersion.Start, 2);
+
+                    page.Messages.Length.ShouldBe(0);
+                }
+            }
+        }
+
+        [Fact, Trait("Category", "AppendStream")]
         public async Task When_append_stream_second_time_with_expected_version_any_and_all_messages_committed_then_should_be_idempotent_first_message()
         {
             using (var fixture = GetFixture())

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamLimits.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamLimits.cs
@@ -10,12 +10,12 @@ namespace SqlStreamStore
     public partial class StreamStoreAcceptanceTests
     {
         [Theory, Trait("Category", "StreamMetadata"),
-         InlineData(ExpectedVersion.NoStream), InlineData(ExpectedVersion.Any), InlineData(ExpectedVersion.EmptyStream)]
+         InlineData(ExpectedVersion.NoStream), InlineData(ExpectedVersion.Any)]
         public async Task When_stream_has_max_count_and_append_exceeds_then_should_maintain_max_count(int expectedVersion)
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     const int maxCount = 2;
@@ -31,14 +31,38 @@ namespace SqlStreamStore
             }
         }
 
+        [Theory, Trait("Category", "StreamMetadata"),
+         InlineData(ExpectedVersion.EmptyStream)]
+        public async Task When_empty_stream_has_max_count_and_append_exceeds_then_should_maintain_max_count(int expectedVersion)
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    const int maxCount = 2;
+                    await store
+                        .SetStreamMetadata(streamId, maxCount: maxCount, metadataJson: "meta");
+                    await store
+                        .AppendToStream(streamId, ExpectedVersion.NoStream, new NewStreamMessage[0]);
+                    await store
+                        .AppendToStream(streamId, expectedVersion, CreateNewStreamMessages(1, 2, 3, 4));
+
+                    var streamMessagesPage = await store.ReadStreamForwards(streamId, StreamVersion.Start, 4);
+
+                    streamMessagesPage.Messages.Length.ShouldBe(maxCount);
+                }
+            }
+        }
+
         [Theory, InlineData(1, 1), InlineData(2, 2), InlineData(6, 4), Trait("Category", "StreamMetadata")]
         public async Task When_stream_max_count_is_set_then_stream_should_have_max_count(
             int maxCount,
             int expectedLength)
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
 
@@ -57,11 +81,11 @@ namespace SqlStreamStore
         [Fact, Trait("Category", "StreamMetadata")]
         public async Task When_stream_has_expired_messages_and_read_forwards_then_should_not_get_expired_messages()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
                 var currentUtc = new DateTime(2016, 1, 1, 0, 0, 0);
                 fixture.GetUtcNow = () => currentUtc;
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     string streamId = "stream-1";
                     await store
@@ -82,11 +106,11 @@ namespace SqlStreamStore
         [Fact, Trait("Category", "StreamMetadata")]
         public async Task When_stream_has_expired_messages_and_read_backward_then_should_not_get_expired_messages()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
                 var currentUtc = new DateTime(2016, 1, 1, 0, 0, 0);
                 fixture.GetUtcNow = () => currentUtc;
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -108,11 +132,11 @@ namespace SqlStreamStore
         public async Task
             When_streams_have_expired_messages_and_read_all_forwards_then_should_not_get_expired_messages()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
                 var currentUtc = new DateTime(2016, 1, 1, 0, 0, 0);
                 fixture.GetUtcNow = () => currentUtc;
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     // Arrange
                     const string streamId1 = "stream-1";
@@ -148,11 +172,11 @@ namespace SqlStreamStore
         public async Task
             When_streams_have_expired_messages_and_read_all_backwards_then_should_not_get_expired_messages()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
                 var currentUtc = new DateTime(2016, 1, 1, 0, 0, 0);
                 fixture.GetUtcNow = () => currentUtc;
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     // Arrange
                     const string streamId1 = "stream-1";

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamLimits.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamLimits.cs
@@ -9,8 +9,9 @@ namespace SqlStreamStore
 
     public partial class StreamStoreAcceptanceTests
     {
-        [Fact, Trait("Category", "StreamMetadata")]
-        public async Task When_stream_has_max_count_and_append_exceeds_then_should_maintain_max_count()
+        [Theory, Trait("Category", "StreamMetadata"),
+         InlineData(ExpectedVersion.NoStream), InlineData(ExpectedVersion.Any), InlineData(ExpectedVersion.EmptyStream)]
+        public async Task When_stream_has_max_count_and_append_exceeds_then_should_maintain_max_count(int expectedVersion)
         {
             using(var fixture = GetFixture())
             {
@@ -21,7 +22,7 @@ namespace SqlStreamStore
                     await store
                         .SetStreamMetadata(streamId, maxCount: maxCount, metadataJson: "meta");
                     await store
-                        .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3, 4));
+                        .AppendToStream(streamId, expectedVersion, CreateNewStreamMessages(1, 2, 3, 4));
 
                     var streamMessagesPage = await store.ReadStreamForwards(streamId, StreamVersion.Start, 4);
 

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -53,7 +53,7 @@
         }
 
         [Fact]
-        public async Task Can_set_and_stream_metadata_for_non_existent_stream_and_create_stream()
+        public async Task Can_set_and_stream_metadata_for_non_existent_stream_and_append()
         {
             using (var fixture = GetFixture())
             {

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -1,5 +1,6 @@
 ﻿namespace SqlStreamStore
 {
+    using System;
     using System.Linq;
     using System.Threading.Tasks;
     using Shouldly;
@@ -53,7 +54,7 @@
         }
 
         [Fact]
-        public async Task Can_set_and_get_stream_metadata_for_non_existent_stream_and_append()
+        public async Task Can_set_stream_metadata_for_non_existent_stream_and_append_with_expected_version_nostream()
         {
             using (var fixture = GetFixture())
             {
@@ -61,14 +62,25 @@
                 {
                     var streamId = "stream-1";
 
-                    await store.SetStreamMetadata(streamId, maxCount: 1, maxAge: 2);
+                    await store.SetStreamMetadata(streamId, maxAge: 20, maxCount: 10);
 
-                    await store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+                    await store.AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1));
+                }
+            }
+        }
 
-                    var metadataResult = await store.GetStreamMetadata(streamId);
+        [Fact]
+        public async Task Can_set_stream_metadata_for_non_existent_stream_and_append_with_expected_version_any()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    var streamId = "stream-1";
 
-                    metadataResult.MaxCount.ShouldBe(1);
-                    metadataResult.MaxAge.ShouldBe(2);
+                    await store.SetStreamMetadata(streamId, maxAge: 20, maxCount: 10);
+
+                    await store.AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1));
                 }
             }
         }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -63,7 +63,7 @@
 
                     await store.SetStreamMetadata(streamId, maxCount: 1);
 
-                    await store.AppendToStream("stream-1", -1, CreateNewStreamMessages(1, 2, 3));
+                    await store.AppendToStream("stream-1", ExpectedVersion.EmptyStream, CreateNewStreamMessages(1, 2, 3));
                 }
             }
         }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -53,7 +53,7 @@
         }
 
         [Fact]
-        public async Task Can_set_and_stream_metadata_for_non_existent_stream_and_append()
+        public async Task Can_set_and_get_stream_metadata_for_non_existent_stream_and_append()
         {
             using (var fixture = GetFixture())
             {
@@ -61,9 +61,14 @@
                 {
                     var streamId = "stream-1";
 
-                    await store.SetStreamMetadata(streamId, maxCount: 1);
+                    await store.SetStreamMetadata(streamId, maxCount: 1, maxAge: 2);
 
-                    await store.AppendToStream("stream-1", ExpectedVersion.EmptyStream, CreateNewStreamMessages(1, 2, 3));
+                    await store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+
+                    var metadataResult = await store.GetStreamMetadata(streamId);
+
+                    metadataResult.MaxCount.ShouldBe(1);
+                    metadataResult.MaxAge.ShouldBe(2);
                 }
             }
         }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.StreamMetadata.cs
@@ -52,6 +52,22 @@
             }
         }
 
+        [Fact]
+        public async Task Can_set_and_stream_metadata_for_non_existent_stream_and_create_stream()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    var streamId = "stream-1";
+
+                    await store.SetStreamMetadata(streamId, maxCount: 1);
+
+                    await store.AppendToStream("stream-1", -1, CreateNewStreamMessages(1, 2, 3));
+                }
+            }
+        }
+
         [Fact, Trait("Category", "StreamMetadata")]
         public async Task Can_set_and_get_stream_metadata_after_stream_is_created()
         {
@@ -128,7 +144,7 @@
             }
         }
 
-        [Fact]
+        [Fact, Trait("Category", "StreamMetadata")]
         public async Task Can_set_deleted_stream_metadata()
         {
             using (var fixture = GetFixture())

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
@@ -102,8 +102,6 @@
 
     public static class TaskExtensions
     {
-        private static Func<int, int> TaskTimeout => timeout => Debugger.IsAttached ? 30000 : timeout;
-
         public static async Task<T> WithTimeout<T>(this Task<T> task, int timeout = 3000)
         {
             if (await Task.WhenAny(task, Task.Delay(timeout)) == task)

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;
     using Shouldly;

--- a/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
+++ b/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
@@ -66,7 +66,7 @@ namespace SqlStreamStore
         public async Task<MsSqlStreamStore> GetUninitializedStreamStore()
         {
             await CreateDatabase();
-            
+
             return new MsSqlStreamStore(new MsSqlStreamStoreSettings(ConnectionString)
             {
                 Schema = _schema,
@@ -172,7 +172,7 @@ namespace SqlStreamStore
         {
             private readonly string _databaseName;
             private readonly DockerContainer _sqlServerContainer;
-            private readonly string _password;
+            private const string Password = "!01u0Yx19PW";
             private const string Image = "microsoft/mssql-server-linux";
             private const string Tag = "2017-CU9";
             private const int Port = 21433;
@@ -180,7 +180,6 @@ namespace SqlStreamStore
             public DockerSqlServerDatabase(string databaseName)
             {
                 _databaseName = databaseName;
-                _password = "!01u0Yx19PW";
 
                 var ports = new Dictionary<int, int>
                 {
@@ -194,7 +193,7 @@ namespace SqlStreamStore
                     ports)
                 {
                     ContainerName = "sql-stream-store-tests-mssql-v2",
-                    Env = new[] { "ACCEPT_EULA=Y", $"SA_PASSWORD={_password}" }
+                    Env = new[] { "ACCEPT_EULA=Y", $"SA_PASSWORD={Password}" }
                 };
             }
 
@@ -202,7 +201,7 @@ namespace SqlStreamStore
                 => new SqlConnection(CreateConnectionStringBuilder().ConnectionString);
 
             public SqlConnectionStringBuilder CreateConnectionStringBuilder()
-                => new SqlConnectionStringBuilder($"server=localhost,{Port};User Id=sa;Password={_password};Initial Catalog=master");
+                => new SqlConnectionStringBuilder($"server=localhost,{Port};User Id=sa;Password={Password};Initial Catalog=master");
 
             public async Task CreateDatabase(CancellationToken cancellationToken = default)
             {

--- a/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
+++ b/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
@@ -172,7 +172,7 @@ namespace SqlStreamStore
         {
             private readonly string _databaseName;
             private readonly DockerContainer _sqlServerContainer;
-            private const string Password = "!01u0Yx19PW";
+            private const string Password = "!Passw0rd";
             private const string Image = "microsoft/mssql-server-linux";
             private const string Tag = "2017-CU9";
             private const int Port = 21433;

--- a/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
+++ b/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
@@ -126,48 +126,6 @@ namespace SqlStreamStore
             return connectionStringBuilder.ToString();
         }
 
-        private interface ISqlServerDatabase
-        {
-            SqlConnection CreateConnection();
-            SqlConnectionStringBuilder CreateConnectionStringBuilder();
-            Task CreateDatabase(CancellationToken cancellationToken = default);
-        }
-
-        private class LocalSqlServerDatabase : ISqlServerDatabase
-        {
-            private readonly string _databaseName;
-            private readonly string _connectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master;Integrated Security=SSPI;";
-
-            public LocalSqlServerDatabase(string databaseName)
-            {
-                _databaseName = databaseName;
-            }
-            public SqlConnection CreateConnection()
-            {
-                return new SqlConnection(_connectionString);
-            }
-
-            public SqlConnectionStringBuilder CreateConnectionStringBuilder()
-            {
-                return new SqlConnectionStringBuilder(_connectionString);
-            }
-
-            public async Task CreateDatabase(CancellationToken cancellationToken = default)
-            {
-                using(var connection = CreateConnection())
-                {
-                    await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
-                    var tempPath = Environment.GetEnvironmentVariable("Temp");
-                    var createDatabase = $"CREATE DATABASE [{_databaseName}] on (name='{_databaseName}', "
-                                         + $"filename='{tempPath}\\{_databaseName}.mdf')";
-                    using (var command = new SqlCommand(createDatabase, connection))
-                    {
-                        await command.ExecuteNonQueryAsync(cancellationToken).NotOnCapturedContext();
-                    }
-                }
-            }
-        }
-
         private class DockerSqlServerDatabase
         {
             private readonly string _databaseName;

--- a/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3AcceptanceTests.cs
+++ b/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3AcceptanceTests.cs
@@ -14,8 +14,7 @@
         { }
 
         protected override StreamStoreAcceptanceTestFixture GetFixture()
-            => new MsSqlStreamStoreV3Fixture("foo");
-
+            => new MsSqlStreamStoreV3Fixture("foo", deleteDatabaseOnDispose: false);
 
         [Fact]
         public async Task Can_use_multiple_schemas()

--- a/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
+++ b/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
@@ -13,14 +13,20 @@ namespace SqlStreamStore
         private readonly string _schema;
         private readonly bool _disableDeletionTracking;
         private readonly string _databaseNameOverride;
+        private readonly bool _deleteDatabaseOnDispose;
         private readonly string _databaseName;
         private readonly DockerSqlServerDatabase _databaseInstance;
 
-        public MsSqlStreamStoreV3Fixture(string schema, bool disableDeletionTracking = false, string databaseNameOverride = null)
+        public MsSqlStreamStoreV3Fixture(
+            string schema,
+            bool disableDeletionTracking = false,
+            string databaseNameOverride = null,
+            bool deleteDatabaseOnDispose = true)
         {
             _schema = schema;
             _disableDeletionTracking = disableDeletionTracking;
             _databaseNameOverride = databaseNameOverride;
+            _deleteDatabaseOnDispose = deleteDatabaseOnDispose;
             _databaseName = databaseNameOverride ?? $"StreamStoreTests-{Guid.NewGuid():n}";
             _databaseInstance = new DockerSqlServerDatabase(_databaseName);
 
@@ -81,6 +87,11 @@ namespace SqlStreamStore
 
         public override void Dispose()
         {
+            if (!_deleteDatabaseOnDispose)
+            {
+                return;
+            }
+
             SqlConnection.ClearAllPools();
 
             using (var connection = _databaseInstance.CreateConnection())

--- a/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
+++ b/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
@@ -129,7 +129,7 @@ namespace SqlStreamStore
         {
             private readonly string _databaseName;
             private readonly DockerContainer _sqlServerContainer;
-            private const string Password = "!01u0Yx19PW";
+            private const string Password = "!Passw0rd";
             private const string Image = "microsoft/mssql-server-linux";
             private const string Tag = "2017-CU9";
             private const int Port = 11433;

--- a/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
+++ b/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
@@ -129,7 +129,7 @@ namespace SqlStreamStore
         {
             private readonly string _databaseName;
             private readonly DockerContainer _sqlServerContainer;
-            private readonly string _password;
+            private const string Password = "!01u0Yx19PW";
             private const string Image = "microsoft/mssql-server-linux";
             private const string Tag = "2017-CU9";
             private const int Port = 11433;
@@ -137,7 +137,6 @@ namespace SqlStreamStore
             public DockerSqlServerDatabase(string databaseName)
             {
                 _databaseName = databaseName;
-                _password = "!01u0Yx19PW";
 
                 var ports = new Dictionary<int, int>
                 {
@@ -151,7 +150,7 @@ namespace SqlStreamStore
                     ports)
                 {
                     ContainerName = "sql-stream-store-tests-mssql-v3",
-                    Env = new[] { "ACCEPT_EULA=Y", $"SA_PASSWORD={_password}" }
+                    Env = new[] { "ACCEPT_EULA=Y", $"SA_PASSWORD={Password}" }
                 };
             }
 
@@ -159,7 +158,7 @@ namespace SqlStreamStore
                 => new SqlConnection(CreateConnectionStringBuilder().ConnectionString);
 
             public SqlConnectionStringBuilder CreateConnectionStringBuilder()
-                => new SqlConnectionStringBuilder($"server=localhost,{Port};User Id=sa;Password={_password};Initial Catalog=master");
+                => new SqlConnectionStringBuilder($"server=localhost,{Port};User Id=sa;Password={Password};Initial Catalog=master");
 
             public async Task CreateDatabase(CancellationToken cancellationToken = default)
             {

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
@@ -275,6 +275,8 @@
                         var currentPosition = reader.GetInt64(1);
                         int? maxCount = null;
 
+                        await reader.NextResultAsync(cancellationToken).NotOnCapturedContext();
+
                         if (await reader.ReadAsync(cancellationToken).NotOnCapturedContext())
                         {
                             var jsonData = reader.GetString(0);
@@ -369,7 +371,8 @@
                         var currentPosition = reader.GetInt64(1);
                         int? maxCount = null;
 
-                        await reader.NextResultAsync(cancellationToken);
+                        await reader.NextResultAsync(cancellationToken).NotOnCapturedContext();
+
                         if (await reader.ReadAsync(cancellationToken).NotOnCapturedContext())
                         {
                             var jsonData = reader.GetString(0);

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
@@ -36,7 +36,7 @@
            CancellationToken cancellationToken)
         {
             Ensure.That(streamId, "streamId").IsNotNullOrWhiteSpace();
-            Ensure.That(expectedVersion, "expectedVersion").IsGte(-2);
+            Ensure.That(expectedVersion, "expectedVersion").IsGte(-3);
             Ensure.That(messages, "Messages").IsNotNull();
             GuardAgainstDisposed();
 
@@ -84,6 +84,16 @@
                         connection,
                         transaction,
                         sqlStreamId,
+                        messages,
+                        cancellationToken);
+                }
+                if (expectedVersion == ExpectedVersion.EmptyStream)
+                {
+                    return AppendToStreamExpectedVersion(
+                        connection,
+                        transaction,
+                        sqlStreamId,
+                        -1,
                         messages,
                         cancellationToken);
                 }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
@@ -41,7 +41,7 @@
            CancellationToken cancellationToken)
         {
             Ensure.That(streamId, "streamId").IsNotNullOrWhiteSpace();
-            Ensure.That(expectedVersion, "expectedVersion").IsGte(-2);
+            Ensure.That(expectedVersion, "expectedVersion").IsGte(-3);
             Ensure.That(messages, "Messages").IsNotNull();
             GuardAgainstDisposed();
 
@@ -94,6 +94,16 @@
                         connection,
                         transaction,
                         sqlStreamId,
+                        messages,
+                        cancellationToken);
+                }
+                if(expectedVersion == ExpectedVersion.EmptyStream)
+                {
+                    return AppendToStreamExpectedVersion(
+                        connection,
+                        transaction,
+                        sqlStreamId,
+                        -1,
                         messages,
                         cancellationToken);
                 }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
@@ -296,7 +296,8 @@
                         if(messages.Length > page.Messages.Length)
                         {
                             throw new WrongExpectedVersionException(
-                                ErrorMessages.AppendFailedWrongExpectedVersion(sqlStreamId.IdOriginal,
+                                ErrorMessages.AppendFailedWrongExpectedVersion(
+                                    sqlStreamId.IdOriginal,
                                     ExpectedVersion.NoStream),
                                 ex);
                         }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.StreamMetadata.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.StreamMetadata.cs
@@ -76,14 +76,14 @@
                         streamId,
                         expectedStreamMetadataVersion,
                         json);
-                    var newmessage = new NewStreamMessage(messageId, "$stream-metadata", json);
+                    var newStreamMessage = new NewStreamMessage(messageId, "$stream-metadata", json);
 
                     result = await AppendToStreamInternal(
                         connection,
                         transaction,
                         streamIdInfo.MetadataSqlStreamId,
                         expectedStreamMetadataVersion,
-                        new[] { newmessage },
+                        new[] { newStreamMessage },
                         cancellationToken);
 
                     using(var command = new SqlCommand(_scripts.SetStreamMetadata, connection, transaction))

--- a/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionAny.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionAny.sql
@@ -56,7 +56,7 @@ BEGIN TRANSACTION CreateStreamIfNotExists;
                     UPDATE dbo.Streams
                     SET dbo.Streams.[MaxAge] = @metadataMaxAge,
                         dbo.Streams.[MaxCount] = @metadataMaxCount
-                    WHERE dbo.Streams.[Id] = '$$' + @streamId
+                    WHERE dbo.Streams.[Id] = @streamId
                
               END
         END

--- a/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionAny.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionAny.sql
@@ -8,8 +8,58 @@ BEGIN TRANSACTION CreateStreamIfNotExists;
         FROM dbo.Streams WITH (UPDLOCK, ROWLOCK, HOLDLOCK)
         WHERE dbo.Streams.Id = @streamId
     )
-        INSERT INTO dbo.Streams (Id, IdOriginal)
-        VALUES (@streamId, @streamIdOriginal);
+        BEGIN
+            INSERT INTO dbo.Streams (Id, IdOriginal)
+            VALUES (@streamId, @streamIdOriginal);
+
+            -- If metadata exists, lift maxAge and maxCount. TODO put this into a function? Duplicate code in Append...NoStream.sql
+            DECLARE @jsonData nvarchar(max);
+            DECLARE @startIndex int;
+            DECLARE @endIndex int;
+            DECLARE @metadataMaxAgeString nvarchar(50);
+            DECLARE @metadataMaxAge int;
+            DECLARE @metadataMaxCountString nvarchar(50);
+            DECLARE @metadataMaxCount int;
+
+            IF EXISTS(SELECT 1 FROM dbo.Streams WITH(NOLOCK)
+                    WHERE dbo.Streams.Id = '$$' + @streamId)
+                BEGIN
+                -- ...read metadata backwards by 1
+                    SELECT TOP(1)
+                        @jsonData = dbo.Messages.JsonData
+                    FROM dbo.Messages
+                INNER JOIN dbo.Streams
+                        ON dbo.Messages.StreamIdInternal = dbo.Streams.IdInternal
+                    WHERE dbo.Streams.Id = '$$' + @streamId
+                ORDER BY dbo.Messages.Position DESC;
+
+                -- Extract MaxAge and MaxCount from Json...
+                    SELECT @startIndex = CHARINDEX('"MaxAge":', @jsonData) + 9;
+                    SELECT @endIndex = CHARINDEX(',', @jsonData, @startIndex);
+                    SELECT @metadataMaxAgeString = SUBSTRING(@jsonData, @startIndex, @endIndex - @startIndex);
+                    SELECT @metadataMaxAge = CASE 
+                                WHEN @metadataMaxAgeString = 'null' 
+                                    THEN NULL 
+                                    ELSE CAST(@metadataMaxAgeString as INT)
+                                END;
+
+                    SELECT @startIndex = CHARINDEX('"MaxCount":', @jsonData) + 11;
+                    SELECT @endIndex = CHARINDEX(',', @jsonData, @startIndex);
+                    SELECT @metadataMaxCountString = SUBSTRING(@jsonData,@startIndex, @endIndex - @startIndex);
+                    SELECT @metadataMaxCount = CASE 
+                                WHEN @metadataMaxCountString = 'null' 
+                                    THEN NULL 
+                                    ELSE CAST(@metadataMaxCountString as INT)
+                                END;
+
+                -- and update the stream row
+                    UPDATE dbo.Streams
+                    SET dbo.Streams.[MaxAge] = @metadataMaxAge,
+                        dbo.Streams.[MaxCount] = @metadataMaxCount
+                    WHERE dbo.Streams.[Id] = '$$' + @streamId
+               
+              END
+        END
 
 COMMIT TRANSACTION CreateStreamIfNotExists;
 

--- a/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionNoStream.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionNoStream.sql
@@ -83,7 +83,7 @@ BEGIN TRANSACTION CreateStream;
                     UPDATE dbo.Streams
                     SET dbo.Streams.[MaxAge] = @metadataMaxAge,
                         dbo.Streams.[MaxCount] = @metadataMaxCount
-                    WHERE dbo.Streams.[Id] = '$$' + @streamId
+                    WHERE dbo.Streams.[Id] = @streamId
                
                     END
 

--- a/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionNoStream.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/AppendStreamExpectedVersionNoStream.sql
@@ -37,6 +37,55 @@ BEGIN TRANSACTION CreateStream;
                 SET @latestStreamPosition = -1
                 SET @latestStreamVersion = -1
             END
+        
+        -- If metadata exists, lift maxAge and maxCount. TODO put this into a function?
+        DECLARE @jsonData nvarchar(max);
+        DECLARE @startIndex int;
+        DECLARE @endIndex int;
+        DECLARE @metadataMaxAgeString nvarchar(50);
+        DECLARE @metadataMaxAge int;
+        DECLARE @metadataMaxCountString nvarchar(50);
+        DECLARE @metadataMaxCount int;
+
+        -- If metadata stream exists...
+        IF EXISTS(SELECT 1 FROM dbo.Streams WITH(NOLOCK)
+                    WHERE dbo.Streams.Id = '$$' + @streamId)
+                BEGIN
+                -- ...read metadata backwards by 1
+                    SELECT TOP(1)
+                        @jsonData = dbo.Messages.JsonData
+                    FROM dbo.Messages
+                INNER JOIN dbo.Streams
+                        ON dbo.Messages.StreamIdInternal = dbo.Streams.IdInternal
+                    WHERE dbo.Streams.Id = '$$' + @streamId
+                ORDER BY dbo.Messages.Position DESC;
+
+                -- Extract MaxAge and MaxCount from Json...
+                    SELECT @startIndex = CHARINDEX('"MaxAge":', @jsonData) + 9;
+                    SELECT @endIndex = CHARINDEX(',', @jsonData, @startIndex);
+                    SELECT @metadataMaxAgeString = SUBSTRING(@jsonData, @startIndex, @endIndex - @startIndex);
+                    SELECT @metadataMaxAge = CASE 
+                                WHEN @metadataMaxAgeString = 'null' 
+                                    THEN NULL 
+                                    ELSE CAST(@metadataMaxAgeString as INT)
+                                END;
+
+                    SELECT @startIndex = CHARINDEX('"MaxCount":', @jsonData) + 11;
+                    SELECT @endIndex = CHARINDEX(',', @jsonData, @startIndex);
+                    SELECT @metadataMaxCountString = SUBSTRING(@jsonData,@startIndex, @endIndex - @startIndex);
+                    SELECT @metadataMaxCount = CASE 
+                                WHEN @metadataMaxCountString = 'null' 
+                                    THEN NULL 
+                                    ELSE CAST(@metadataMaxCountString as INT)
+                                END;
+
+                -- and update the stream row
+                    UPDATE dbo.Streams
+                    SET dbo.Streams.[MaxAge] = @metadataMaxAge,
+                        dbo.Streams.[MaxCount] = @metadataMaxCount
+                    WHERE dbo.Streams.[Id] = '$$' + @streamId
+               
+                    END
 
     END;
 

--- a/src/SqlStreamStore.MsSql/ScriptsV3/SetStreamMetadata.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/SetStreamMetadata.sql
@@ -1,13 +1,10 @@
-IF NOT EXISTS (
+-- If the stream exists, lift the maxCount and maxAge metadata to the streams table
+
+IF EXISTS (
     SELECT *
     FROM dbo.Streams WITH (UPDLOCK, ROWLOCK, HOLDLOCK)
     WHERE dbo.Streams.Id = @streamId
 )
-BEGIN
-    INSERT INTO dbo.Streams (Id, IdOriginal, MaxAge, MaxCount)
-    VALUES (@streamId, @streamIdOriginal, @maxAge, @maxCount);
-END
-ELSE
 BEGIN
     UPDATE dbo.Streams
     SET dbo.Streams.[MaxAge] = @maxAge,

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
@@ -14,7 +14,8 @@ DECLARE
   _stream_id_internal INT;
   _success            INT;
 BEGIN
-  IF _created_utc IS NULL THEN
+  IF _created_utc IS NULL
+  THEN
     _created_utc = now() at time zone 'utc';
   END IF;
 
@@ -24,8 +25,22 @@ BEGIN
     INSERT INTO __schema__.streams (id, id_original)
     SELECT _stream_id, _stream_id_original
     ON CONFLICT DO NOTHING;
+  ELSEIF _expected_version = -1 /* ExpectedVersion.Empty */
+    THEN
 
-  ELSIF _expected_version = -1 /* ExpectedVersion.NoStream */
+      INSERT INTO __schema__.streams (id, id_original)
+      SELECT _stream_id, _stream_id_original
+      ON CONFLICT DO NOTHING;
+
+      GET DIAGNOSTICS _success = ROW_COUNT;
+      IF _success = 0 AND
+         cardinality(_new_stream_messages) > 0 AND
+         (SELECT __schema__.streams.version FROM __schema__.streams WHERE _stream_id_internal = _stream_id_internal) > 0
+      THEN
+
+        RAISE EXCEPTION 'WrongExpectedVersion';
+      END IF;
+  ELSIF _expected_version = -3 /* ExpectedVersion.NoStream */
     THEN
 
       INSERT INTO __schema__.streams (id, id_original)
@@ -53,12 +68,14 @@ BEGIN
   END IF;
 
   SELECT (CASE _expected_version
-            WHEN -2 THEN coalesce(
+            WHEN -2 /* ExpectedVersion.Any */
+                    THEN coalesce(
                            __schema__.read_stream_version_of_message_id(
                              __schema__.streams.id_internal,
                              _new_stream_messages [ 1 ].message_id) - 1,
                            __schema__.streams.version)
-            WHEN -1 THEN -1
+            WHEN -3 THEN -1 /* ExpectedVersion.NoStream */
+            WHEN -1 THEN -1 /* ExpectedVersion.Empty */
             ELSE _expected_version END), __schema__.streams.position, __schema__.streams.id_internal
       INTO _current_version, _current_position, _stream_id_internal
   FROM __schema__.streams
@@ -93,12 +110,18 @@ BEGIN
                   _stream_id,
                   _current_version + 1 - _success,
                   false,
-                  _new_stream_messages
-                    );
+                  _new_stream_messages);
 
-      ELSEIF _expected_version = -1 /* ExpectedVersion.NoStream */
+      ELSEIF _expected_version = -3 /* ExpectedVersion.NoStream */
         THEN
           RAISE EXCEPTION 'WhyAreYouHere'; /* there is no way to get here? */
+      ELSEIF _expected_version = -1 /* ExpectedVersion.Empty */
+        THEN
+          PERFORM __schema__.enforce_idempotent_append(
+                    _stream_id,
+                    0,
+                    false,
+                    _new_stream_messages);
       ELSE
         PERFORM __schema__.enforce_idempotent_append(
                   _stream_id,
@@ -123,7 +146,7 @@ BEGIN
     ORDER BY __schema__.messages.position DESC
     LIMIT 1;
 
-    UPDATE __schema__ . streams
+    UPDATE __schema__.streams
     SET "version"  = _current_version,
         "position" = _current_position
     WHERE id_internal = _stream_id_internal;

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
@@ -1,6 +1,7 @@
 CREATE OR REPLACE FUNCTION __schema__.append_to_stream(
   _stream_id           CHAR(42),
   _stream_id_original  VARCHAR(1000),
+  _metadata_stream_id  CHAR(42),
   _expected_version    INT,
   _created_utc         TIMESTAMP,
   _new_stream_messages __schema__.new_stream_message [])
@@ -13,42 +14,43 @@ DECLARE
   _current_position   BIGINT;
   _stream_id_internal INT;
   _success            INT;
+  _max_age            INT;
+  _max_count          INT;
 BEGIN
   IF _created_utc IS NULL
   THEN
     _created_utc = now() at time zone 'utc';
   END IF;
 
-  IF _expected_version = -2 /* ExpectedVersion.Any */
+  IF _expected_version < 0
+  THEN
+    SELECT __schema__.messages.json_data :: JSON->>'MaxAge', __schema__.messages.json_data :: JSON->>'MaxCount'
+        INTO _max_age, _max_count
+    FROM __schema__.messages
+           JOIN __schema__.streams ON __schema__.messages.stream_id_internal = __schema__.streams.id_internal
+    WHERE __schema__.streams.id = _metadata_stream_id
+    ORDER BY __schema__.messages.stream_version DESC
+    LIMIT 1;
+
+    INSERT INTO __schema__.streams (id, id_original, max_age, max_count)
+    SELECT _stream_id, _stream_id_original, _max_age, _max_count
+    ON CONFLICT DO NOTHING;
+    GET DIAGNOSTICS _success = ROW_COUNT;
+
+  END IF;
+
+  IF _expected_version = -1 /* ExpectedVersion.Empty */
   THEN
 
-    INSERT INTO __schema__.streams (id, id_original)
-    SELECT _stream_id, _stream_id_original
-    ON CONFLICT DO NOTHING;
-  ELSEIF _expected_version = -1 /* ExpectedVersion.Empty */
+    IF _success = 0 AND
+       cardinality(_new_stream_messages) > 0 AND
+       (SELECT __schema__.streams.version FROM __schema__.streams WHERE _stream_id_internal = _stream_id_internal) > 0
     THEN
 
-      INSERT INTO __schema__.streams (id, id_original)
-      SELECT _stream_id, _stream_id_original
-      ON CONFLICT DO NOTHING;
-
-      GET DIAGNOSTICS _success = ROW_COUNT;
-      IF _success = 0 AND
-         cardinality(_new_stream_messages) > 0 AND
-         (SELECT __schema__.streams.version FROM __schema__.streams WHERE _stream_id_internal = _stream_id_internal) > 0
-      THEN
-
-        RAISE EXCEPTION 'WrongExpectedVersion';
-      END IF;
+      RAISE EXCEPTION 'WrongExpectedVersion';
+    END IF;
   ELSIF _expected_version = -3 /* ExpectedVersion.NoStream */
     THEN
-
-      INSERT INTO __schema__.streams (id, id_original)
-      SELECT _stream_id, _stream_id_original
-      ON CONFLICT DO NOTHING;
-
-      GET DIAGNOSTICS _success = ROW_COUNT;
-
       IF _success = 0 AND cardinality(_new_stream_messages) > 0
       THEN
         PERFORM __schema__.enforce_idempotent_append(

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStream.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStream.sql
@@ -12,7 +12,8 @@ DECLARE
   _latest_stream_version INT;
   _affected              INT;
 BEGIN
-  IF _created_utc IS NULL THEN
+  IF _created_utc IS NULL
+  THEN
     _created_utc = now() at time zone 'utc';
   END IF;
   SELECT __schema__.streams.id_internal
@@ -54,6 +55,7 @@ BEGIN
     PERFORM __schema__.append_to_stream(
               _deleted_stream_id,
               _deleted_stream_id_original,
+              NULL,
               -2,
               _created_utc,
               ARRAY [_deleted_stream_message]);

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStreamMessages.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/DeleteStreamMessages.sql
@@ -34,6 +34,7 @@ BEGIN
     PERFORM __schema__.append_to_stream(
               _deleted_stream_id,
               _deleted_stream_id_original,
+              NULL,
               -2,
               _created_utc,
               _deleted_messages);

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/SetStreamMetadata.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/SetStreamMetadata.sql
@@ -1,6 +1,5 @@
 CREATE OR REPLACE FUNCTION __schema__.set_stream_metadata(
   _stream_id                   CHAR(42),
-  _stream_id_original          VARCHAR(1000),
   _metadata_stream_id          CHAR(42),
   _metadata_stream_id_original CHAR(42),
   _max_age                     INT,
@@ -11,9 +10,9 @@ CREATE OR REPLACE FUNCTION __schema__.set_stream_metadata(
   RETURNS INT AS $F$
 DECLARE
   _current_version INT;
-  _stream_updated  INT;
 BEGIN
-  IF _created_utc IS NULL THEN
+  IF _created_utc IS NULL
+  THEN
     _created_utc = now() at time zone 'utc';
   END IF;
 
@@ -21,6 +20,7 @@ BEGIN
   FROM __schema__.append_to_stream(
          _metadata_stream_id,
          _metadata_stream_id_original,
+         NULL,
          _expected_version,
          _created_utc,
          ARRAY [_metadata_message]
@@ -31,21 +31,6 @@ BEGIN
   SET max_age   = _max_age,
       max_count = _max_count
   WHERE __schema__.streams.id = _stream_id;
-  GET DIAGNOSTICS _stream_updated = ROW_COUNT;
-
-  IF (_stream_updated = 0)
-  THEN
-    PERFORM __schema__.append_to_stream(
-              _stream_id,
-              _stream_id_original,
-              -1,
-              _created_utc,
-              ARRAY [] :: __schema__.new_stream_message []);
-    UPDATE __schema__.streams
-    SET max_age   = _max_age,
-        max_count = _max_count
-    WHERE __schema__.streams.id = _stream_id;
-  END IF;
 
   RETURN _current_version;
 END;

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/Tables.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/Tables.sql
@@ -10,14 +10,15 @@ CREATE TABLE IF NOT EXISTS __schema__.streams (
   max_age     INT           NULL,
   max_count   INT           NULL,
   CONSTRAINT pk_streams PRIMARY KEY (id_internal),
-  CONSTRAINT uq_streams_id UNIQUE (id)
+  CONSTRAINT uq_streams_id UNIQUE (id),
+  CONSTRAINT ck_version_gte_negative_one CHECK (version >= -1)
 );
 
 COMMENT ON SCHEMA __schema__
 IS '{ "version": 1 }';
 
 ALTER SEQUENCE __schema__.streams_seq
-OWNED BY __schema__.streams.id_internal;
+  OWNED BY __schema__.streams.id_internal;
 
 CREATE SEQUENCE IF NOT EXISTS __schema__.messages_seq
   START 0
@@ -35,11 +36,12 @@ CREATE TABLE IF NOT EXISTS __schema__.messages (
   CONSTRAINT pk_messages PRIMARY KEY (position),
   CONSTRAINT fk_messages_stream FOREIGN KEY (stream_id_internal) REFERENCES __schema__.streams (id_internal),
   CONSTRAINT uq_messages_stream_id_internal_and_stream_version UNIQUE (stream_id_internal, stream_version),
-  CONSTRAINT uq_stream_id_internal_and_message_id UNIQUE (stream_id_internal, message_id)
+  CONSTRAINT uq_stream_id_internal_and_message_id UNIQUE (stream_id_internal, message_id),
+  CONSTRAINT ck_stream_version_gte_zero CHECK (stream_version >= 0)
 );
 
 ALTER SEQUENCE __schema__.messages_seq
-OWNED BY __schema__.messages.position;
+  OWNED BY __schema__.messages.position;
 
 DO $F$
 BEGIN

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.Append.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.Append.cs
@@ -35,6 +35,7 @@
                         transaction,
                         Parameters.StreamId(streamIdInfo.PostgresqlStreamId),
                         Parameters.StreamIdOriginal(streamIdInfo.PostgresqlStreamId),
+                        Parameters.MetadataStreamId(streamIdInfo.MetadataPosgresqlStreamId),
                         Parameters.ExpectedVersion(expectedVersion),
                         Parameters.CreatedUtc(_settings.GetUtcNow?.Invoke()),
                         Parameters.NewStreamMessages(messages)))

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.Metadata.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.Metadata.cs
@@ -78,7 +78,6 @@
                 _schema.SetStreamMetadata,
                 transaction,
                 Parameters.StreamId(streamIdInfo.PostgresqlStreamId),
-                Parameters.StreamIdOriginal(streamIdInfo.PostgresqlStreamId),
                 Parameters.MetadataStreamId(streamIdInfo.MetadataPosgresqlStreamId),
                 Parameters.MetadataStreamIdOriginal(streamIdInfo.MetadataPosgresqlStreamId),
                 Parameters.OptionalMaxAge(metadata.MaxAge),

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
@@ -214,8 +214,18 @@
                         }
                     }
 
+                    if(Logger.IsInfoEnabled())
+                    {
+                        Logger.Info($"Found {deletedMessageIds.Count} message(s) for stream {streamIdInfo.PostgresqlStreamId} to scavenge.");
+                    }
+
                     if(deletedMessageIds.Count > 0)
                     {
+                        if(Logger.IsDebugEnabled())
+                        {
+                            Logger.Debug($"Scavenging the following messages on stream {streamIdInfo.PostgresqlStreamId}: {string.Join(", ", deletedMessageIds)}");
+                        }
+
                         await DeleteEventsInternal(
                             streamIdInfo,
                             deletedMessageIds.ToArray(),

--- a/src/SqlStreamStore.Postgres/PostgresqlStreamId.cs
+++ b/src/SqlStreamStore.Postgres/PostgresqlStreamId.cs
@@ -44,5 +44,7 @@
                 return (Id.GetHashCode() * 397) ^ IdOriginal.GetHashCode();
             }
         }
+
+        public override string ToString() => IdOriginal;
     }
 }

--- a/src/SqlStreamStore.TestUtils/DockerContainer.cs
+++ b/src/SqlStreamStore.TestUtils/DockerContainer.cs
@@ -52,16 +52,16 @@ namespace SqlStreamStore
             if (images.Count == 0)
             {
                 // No image found. Pulling latest ..
+
+                var imagesCreateParameters = new ImagesCreateParameters
+                {
+                    FromImage = _image,
+                    Tag = _tag
+                };
+
                 await _dockerClient
                     .Images
-                    .CreateImageAsync(new ImagesCreateParameters
-                    {
-                        FromImage = _image,
-                        Tag = _tag
-                    },
-                        null,
-                        IgnoreProgress.Forever,
-                        cancellationToken)
+                    .CreateImageAsync(imagesCreateParameters, null, IgnoreProgress.Forever, cancellationToken)
                     .NotOnCapturedContext();
             }
 

--- a/src/SqlStreamStore.Tests/SqlStreamStore.Tests.v3.ncrunchproject
+++ b/src/SqlStreamStore.Tests/SqlStreamStore.Tests.v3.ncrunchproject
@@ -1,0 +1,3 @@
+﻿<ProjectConfiguration>
+  <Settings />
+</ProjectConfiguration>

--- a/src/SqlStreamStore/SqlStreamStore.csproj
+++ b/src/SqlStreamStore/SqlStreamStore.csproj
@@ -18,8 +18,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SimpleJson" Version="0.38.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/SqlStreamStore/Streams/ExpectedVersion.cs
+++ b/src/SqlStreamStore/Streams/ExpectedVersion.cs
@@ -6,12 +6,20 @@
     public static class ExpectedVersion
     {
         /// <summary>
+        ///     Stream should exist but be empty. If stream does not exist, or
+        ///     contains messages, then will be considered a concurrency problem.
+        /// </summary>
+        public const int EmptyStream = -1;
+
+        /// <summary>
         ///     Any version.
         /// </summary>
         public const int Any = -2;
 
         /// <summary>
-        ///     Stream should not exist. If stream exists, then will be considered a concurrency problem.
+        ///     Stream should not exist. If stream exists, then will be considered
+        ///     a concurrency problem.
         /// </summary>
-        public const int NoStream = -1;    }
+        public const int NoStream = -3;
+    }
 }

--- a/src/SqlStreamStore/Streams/ExpectedVersion.cs
+++ b/src/SqlStreamStore/Streams/ExpectedVersion.cs
@@ -11,8 +11,7 @@
         public const int Any = -2;
 
         /// <summary>
-        ///     Stream does not exist.
+        ///     Stream should not exist. If stream exists, then will be considered a concurrency problem.
         /// </summary>
-        public const int NoStream = -1;
-    }
+        public const int NoStream = -1;    }
 }


### PR DESCRIPTION
Adds test and fix to append to an empty stream

Also fixes behaviour in MsSql v3 where it was creating an empty stream if setting metadata and the stream didn't exist. This was tricky because, for performance reasons we lift a copy of `MaxAge` and `MaxCount` to the stream table. But since the stream doesn't yet exist we need to lift it when the stream comes into existence later.