### PR TITLE
add $ErrorActionPreference = "Stop"; to build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop";
+
 # Install .NET Core
 
 $dotNetVersionString = dotnet --version


### PR DESCRIPTION
Just in case this is ever used on a build server (without this, the build will succeed even if the script fails).