### PR TITLE
Increase Travis Timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: minimal
 sudo: required
 dist: trusty
-script: "./build.sh"
+script: travis_wait "./build.sh"
 env:
   global:
     secure: e2TyjuwV8DgvfkM/NsZw7Q2Trt7IDO6roqQJHa/xbQh4ZInp2JPLgg/f6YVF51dpBxfxsmYSLBbsnj8SLoTuSa904lyoI7p/xY1CDvvQUPiBQD2ORkSkne7RWepZXg5uwm9DQTJJXohR/aPnpNnFGr8RWMhCfIOPgc6wEX7EVCA=

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -48,7 +48,7 @@ namespace build
                     "SqlStreamStore.MsSql.V3.Tests",
                     "SqlStreamStore.Postgres.Tests",
                     "SqlStreamStore.Http.Tests"),
-                project => Run("dotnet", $"test src/{project}/{project}.csproj -c Release -r ../../{ArtifactsDir} --no-build -l trx;LogFileName={project}.xml"));
+                project => Run("dotnet", $"test src/{project}/{project}.csproj -c Release -r ../../{ArtifactsDir} --no-build -l trx;LogFileName={project}.xml --verbosity=normal"));
 
             Target(
                 Pack,


### PR DESCRIPTION
If travis doesn't receive any output for 10 minutes it fails the build. Some of our tests are taking almost that long: https://travis-ci.org/SQLStreamStore/SQLStreamStore/builds/426112365#L711