### PR TITLE
fix build arg passing

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,1 @@
-docker run --rm --name sss-build -v %cd%:/repo -v /var/run/docker.sock:/var/run/docker.sock -w /repo --network host microsoft/dotnet:2.1.401-sdk-alpine dotnet run -p build/build.csproj %*
+docker run --rm --name sss-build -v %cd%:/repo -v /var/run/docker.sock:/var/run/docker.sock -w /repo --network host microsoft/dotnet:2.1.401-sdk-alpine dotnet run -p build/build.csproj -- %*

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm --name sss-build -v $(pwd):/repo -v /var/run/docker.sock:/var/run/docker.sock -w /repo --network host microsoft/dotnet:2.1.401-sdk-alpine dotnet run -p build/build.csproj "$@"
+docker run --rm --name sss-build -v $(pwd):/repo -v /var/run/docker.sock:/var/run/docker.sock -w /repo --network host microsoft/dotnet:2.1.401-sdk-alpine dotnet run -p build/build.csproj -- "$@"


### PR DESCRIPTION
Relates to https://github.com/SQLStreamStore/SQLStreamStore/pull/168

Without this, `dotnet` was intercepting some options, e.g. `-h`.