### PR TITLE
remove travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: minimal
 sudo: required
 dist: trusty
-script: travis_wait "./build.sh"
+script: ./build.sh
 env:
   global:
     secure: e2TyjuwV8DgvfkM/NsZw7Q2Trt7IDO6roqQJHa/xbQh4ZInp2JPLgg/f6YVF51dpBxfxsmYSLBbsnj8SLoTuSa904lyoI7p/xY1CDvvQUPiBQD2ORkSkne7RWepZXg5uwm9DQTJJXohR/aPnpNnFGr8RWMhCfIOPgc6wEX7EVCA=


### PR DESCRIPTION
The build has been failing since #172 was merged due to the addition of `travis_wait`. This is because the build takes longer than 20 minutes, and `travis_wait` only extends the build by up to 20 minutes by default.

While a parameter can be passed to `travis_wait` to make the period longer, this shouldn't be required after adding `--verbosity=normal` to the `dotnet test` command, since each test result will be printed as it happens, and no individual test takes anywhere near 10 minutes.