### PR TITLE
Use intermediate Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**/bin/
+**/obj/
+**/global.json
+**/Dockerfile*
+**/.dockerignore*
+**/*.user
+.idea/
+.vs/
+.vscode/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.401-sdk-alpine3.7 AS build
+FROM microsoft/dotnet:2.1.402-sdk-alpine3.7 AS build
 WORKDIR /src
 
 COPY ./src/*.sln ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM microsoft/dotnet:2.1.401-sdk-alpine3.7 AS build
+WORKDIR /src
+
+COPY ./src/*.sln ./
+COPY ./src/*/*.csproj ./
+RUN for file in $(ls *.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done
+
+COPY ./NuGet.Config ./
+
+RUN dotnet restore
+
+COPY ./src .
+
+WORKDIR /build
+
+COPY ./build/build.csproj .
+
+RUN dotnet restore
+
+COPY ./build .
+
+WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM microsoft/dotnet:2.1.402-sdk-alpine3.7 AS build
 WORKDIR /src
 
+# https://github.com/moby/moby/issues/15858
+# Docker will flatten out the file structure on COPY
+# We don't want to specify each csproj either - it creates pointless layers and it looks ugly
+# https://code-maze.com/aspnetcore-app-dockerfiles/
 COPY ./src/*.sln ./
 COPY ./src/*/*.csproj ./
 RUN for file in $(ls *.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done

--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,2 @@
-docker run --rm --name sss-build -v %cd%:/repo -v /var/run/docker.sock:/var/run/docker.sock -w /repo --network host microsoft/dotnet:2.1.401-sdk-alpine dotnet run -p build/build.csproj -- %*
+docker build --tag sss-build . && docker run --rm --name sss-build -v /var/run/docker.sock:/var/run/docker.sock --network host sss-build dotnet run -p /build/build.csproj -- %*
+

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker build --tag sss-build . && docker run --rm --name sss-build -v /var/run/docker.sock:/var/run/docker.sock --network host sss-build dotnet run -p /build/build.csproj -- "$@"
+docker build --tag sss-build . && docker run --rm --name sss-build -v /var/run/docker.sock:/var/run/docker.sock --network host -e TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER -e MYGET_API_KEY=$MYGET_API_KEY sss-build dotnet run -p /build/build.csproj -- "$@"
 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-docker run --rm --name sss-build -v $(pwd):/repo -v /var/run/docker.sock:/var/run/docker.sock -w /repo --network host microsoft/dotnet:2.1.401-sdk-alpine dotnet run -p build/build.csproj -- "$@"
+docker build --tag sss-build . && docker run --rm --name sss-build -v /var/run/docker.sock:/var/run/docker.sock --network host sss-build dotnet run -p /build/build.csproj -- "$@"
+


### PR DESCRIPTION
`-v %cd%:/repo` is causing problems on linux, since the container is running as root and creating files during the build, which then end up on the host's filesystem. Since these files have permissions 0600 you can't overwrite them without sudo - e.g. when you run a build via your IDE.