### PR TITLE
remove redundant dotnet restore commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,11 @@ RUN for file in $(ls *.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.
 
 COPY ./NuGet.Config ./
 
-RUN dotnet restore
-
 COPY ./src .
 
 WORKDIR /build
 
 COPY ./build/build.csproj .
-
-RUN dotnet restore
 
 COPY ./build .
 


### PR DESCRIPTION
The restore for the `build` project is done as part of `dotnet run`, and the restore for the solution is done as part of `dotnet build` in the `build` target.

The restores in `Dockerfile` are redundant, and they add to the build time unnecessarily. The solution restore is especially redundant when running `build.cmd` in a way that does not run the `build` target. E.g. `build.cmd -n`, `build.cmd -D -I`, etc.

The removal of these lines may also make some of the other lines in the file redundant, but being a Docker noob I'm not 100% sure, so I'm leaving the rest as-is.