### PR TITLE
upgrade to Bullseye 2.0.0 RC

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="1.3.0" />
+    <PackageReference Include="Bullseye" Version="2.0.0-rc.3" />
     <PackageReference Include="SimpleExec" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The main new feature in this release is the [`--parallel` option](https://github.com/adamralph/bullseye/issues/69).

As noted in the issue, you may want to think twice about using it for CI, but it's awesome for local builds. I tried it locally and the build time went from ~15 minutes to ~7.5 minutes, almost spot-on twice as fast.

However, it doesn't seem to work well with Docker. When running inside Docker, the build seems to hang when the targets are finished, and sometimes there are conflicts with the test containers, e.g.

```
Failed   SqlStreamStore.MigrationTests.Can_migrate
Error Message:
 Docker.DotNet.DockerApiException : Docker API responded with status code=Conflict, response={"message":"Conflict. The container name \"/sql-stream-store-tests-mssql-v2\" is already in use by container \"2d7627c9461932b3efccfc5eb371e08f48c68bdf9785c632b04ef2097bff6b20\". You have to remove (or rename) that container to be able to reuse that name."}
```

After I removed the Docker wrapper in `build.cmd` and ran a non-Docker build, it worked perfectly.

I guess the test container conflict could also occur when running a non-Docker build because the tests are still spinning up the same Docker containers. Perhaps I just got lucky there, and perhaps the test projects need some tweaking before they are truly parallel-friendly.

As for the Docker build hanging when trying to exit, I really have no idea.

Anyway, there's more to 2.0.0 than just the `--parallel` option, so even if you can't use that, it's still worth upgrading. There's also more nice stuff coming in 2.1.0.

As usual, this is a proper RC, and if no bugs are found, the same commit will be used to build RTM.