### PR TITLE
ensure API key is hidden in build output

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -71,7 +71,7 @@ namespace build
 
                 foreach (var packageToPush in packagesToPush)
                 {
-                    Run("dotnet", $"nuget push {packageToPush} -s https://www.myget.org/F/sqlstreamstore/api/v3/index.json -k {apiKey}");
+                    Run("dotnet", $"nuget push {packageToPush} -s https://www.myget.org/F/sqlstreamstore/api/v3/index.json -k {apiKey}", true);
                 }
             });
 


### PR DESCRIPTION
I _think_ Travis CI is smart enough to hide anything in the output which originates from a secure value, but it's probably better to be explicit and suppress the console echo for the `nuget push` commands.

It's probably better to regard the Travis CI security feature as a fallback mechanism. E.g. you might choose to switch CI hosts in the future.