### PR TITLE
Make streamId a sql parameter of type SqlDbType.Char

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
@@ -131,7 +131,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionAny, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
                 if (messages.Any())
@@ -236,7 +236,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionNoStream, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
                 if(messages.Length != 0)
@@ -343,7 +343,7 @@
 
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersion, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                 var eventsParam = CreateNewMessagesSqlParameter(sqlDataRecords);
                 command.Parameters.Add(eventsParam);
@@ -459,7 +459,7 @@
         {
             using(var command = new SqlCommand(_scripts.GetStreamVersionOfMessageId, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("messageId", messageId);
 
                 var result = await command.ExecuteScalarAsync(cancellationToken)

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.Delete.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.Delete.cs
@@ -1,6 +1,7 @@
 namespace SqlStreamStore
 {
     using System;
+    using System.Data;
     using System.Data.SqlClient;
     using System.Threading;
     using System.Threading.Tasks;
@@ -38,7 +39,7 @@ namespace SqlStreamStore
                     bool deleted;
                     using (var command = new SqlCommand(_scripts.DeleteStreamMessage, connection, transaction))
                     {
-                        command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                        command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                         command.Parameters.AddWithValue("eventId", eventId);
                         var count  = await command
                             .ExecuteScalarAsync(cancellationToken)
@@ -76,7 +77,7 @@ namespace SqlStreamStore
                 {
                     using(var command = new SqlCommand(_scripts.DeleteStreamExpectedVersion, connection, transaction))
                     {
-                        command.Parameters.AddWithValue("streamId", streamIdInfo.SqlStreamId.Id);
+                        command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                         command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                         try
                         {
@@ -142,7 +143,7 @@ namespace SqlStreamStore
             bool aStreamIsDeleted;
             using (var command = new SqlCommand(_scripts.DeleteStreamAnyVersion, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 var i = await command
                     .ExecuteScalarAsync(cancellationToken)
                     .NotOnCapturedContext();

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Data;
     using System.Data.SqlClient;
     using System.Linq;
     using System.Threading;
@@ -107,7 +108,7 @@
 
             using (var command = new SqlCommand(commandText, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("count", count + 1); //Read extra row to see if at end or not
                 command.Parameters.AddWithValue("streamVersion", streamVersion);
 
@@ -201,7 +202,7 @@
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
                 using(var command = new SqlCommand(_scripts.ReadMessageData, connection))
                 {
-                    command.Parameters.AddWithValue("streamId", streamId);
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamId });
                     command.Parameters.AddWithValue("streamVersion", streamVersion);
 
                     var jsonData = (string)await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
@@ -211,7 +211,7 @@
                 using(var command = new SqlCommand(_scripts.GetStreamMessageCount, connection))
                 {
                     var streamIdInfo = new StreamIdInfo(streamId);
-                    command.Parameters.AddWithValue("streamId", streamIdInfo.SqlStreamId.Id);
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
 
                     var result = await command
                         .ExecuteScalarAsync(cancellationToken)
@@ -236,7 +236,7 @@
                 using (var command = new SqlCommand(_scripts.GetStreamMessageBeforeCreatedCount, connection))
                 {
                     var streamIdInfo = new StreamIdInfo(streamId);
-                    command.Parameters.AddWithValue("streamId", streamIdInfo.SqlStreamId.Id);
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                     command.Parameters.AddWithValue("created", createdBefore);
 
                     var result = await command

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
@@ -141,7 +141,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionAny, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
                 if (messages.Any())
@@ -241,7 +241,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionNoStream, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
                 if(messages.Length != 0)
@@ -344,7 +344,7 @@
 
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersion, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                 var eventsParam = CreateNewMessagesSqlParameter(sqlDataRecords);
                 command.Parameters.Add(eventsParam);
@@ -453,7 +453,7 @@
         {
             using(var command = new SqlCommand(_scripts.GetStreamVersionOfMessageId, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("messageId", messageId);
 
                 var result = await command.ExecuteScalarAsync(cancellationToken)

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.Delete.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.Delete.cs
@@ -1,6 +1,7 @@
 namespace SqlStreamStore
 {
     using System;
+    using System.Data;
     using System.Data.SqlClient;
     using System.Threading;
     using System.Threading.Tasks;
@@ -37,7 +38,7 @@ namespace SqlStreamStore
                     bool deleted;
                     using (var command = new SqlCommand(_scripts.DeleteStreamMessage, connection, transaction))
                     {
-                        command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                        command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                         command.Parameters.AddWithValue("eventId", eventId);
                         var count  = await command
                             .ExecuteScalarAsync(cancellationToken)
@@ -75,7 +76,7 @@ namespace SqlStreamStore
                 {
                     using(var command = new SqlCommand(_scripts.DeleteStreamExpectedVersion, connection, transaction))
                     {
-                        command.Parameters.AddWithValue("streamId", streamIdInfo.SqlStreamId.Id);
+                        command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                         command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                         try
                         {
@@ -144,7 +145,7 @@ namespace SqlStreamStore
             bool aStreamIsDeleted;
             using (var command = new SqlCommand(_scripts.DeleteStreamAnyVersion, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 var i = await command
                     .ExecuteScalarAsync(cancellationToken)
                     .NotOnCapturedContext();

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Data;
     using System.Data.SqlClient;
     using System.Linq;
     using System.Threading;
@@ -101,7 +102,7 @@
 
             using(var command = new SqlCommand(commandText, connection, transaction))
             {
-                command.Parameters.AddWithValue("streamId", sqlStreamId.Id);
+                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("count", count + 1); //Read extra row to see if at end or not
                 command.Parameters.AddWithValue("streamVersion", streamVersion);
 
@@ -202,7 +203,7 @@
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
                 using(var command = new SqlCommand(_scripts.ReadMessageData, connection))
                 {
-                    command.Parameters.AddWithValue("streamId", streamId);
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamId });
                     command.Parameters.AddWithValue("streamVersion", streamVersion);
 
                     var jsonData = (string)await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.StreamMetadata.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.StreamMetadata.cs
@@ -88,7 +88,7 @@
 
                     using(var command = new SqlCommand(_scripts.SetStreamMetadata, connection, transaction))
                     {
-                        command.Parameters.AddWithValue("streamId", streamIdInfo.SqlStreamId.Id);
+                        command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                         command.Parameters.AddWithValue("streamIdOriginal", streamIdInfo.SqlStreamId.IdOriginal);
                         command.Parameters.Add("maxAge", SqlDbType.Int);
                         command.Parameters["maxAge"].Value = maxAge ?? -1;

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
@@ -181,7 +181,7 @@
                 using(var command = new SqlCommand(_scripts.GetStreamMessageCount, connection))
                 {
                     var streamIdInfo = new StreamIdInfo(streamId);
-                    command.Parameters.AddWithValue("streamId", streamIdInfo.SqlStreamId.Id);
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
 
                     var result = await command
                         .ExecuteScalarAsync(cancellationToken)
@@ -206,7 +206,7 @@
                 using (var command = new SqlCommand(_scripts.GetStreamMessageBeforeCreatedCount, connection))
                 {
                     var streamIdInfo = new StreamIdInfo(streamId);
-                    command.Parameters.AddWithValue("streamId", streamIdInfo.SqlStreamId.Id);
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                     command.Parameters.AddWithValue("created", createdBefore);
 
                     var result = await command
@@ -294,7 +294,7 @@
 
                             using(var command = new SqlCommand(_scripts.SetStreamMetadata, connection))
                             {
-                                command.Parameters.AddWithValue("streamId", new StreamIdInfo(streamId).SqlStreamId.Id);
+                                command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
                                 command.Parameters.AddWithValue("streamIdOriginal", "ignored");
                                 command.Parameters.Add("maxAge", SqlDbType.Int);
                                 command.Parameters["maxAge"].Value = (object)metadata.MaxAge ?? DBNull.Value;


### PR DESCRIPTION
In our project we saw serious performance issues when having millions of streams.
This issue was caused by a CONVERT_IMPLICIT() function that was always executed when searching streams by streamId. 
Our streamId was a regular Guid and the parameter type got translated to a nvarchar(36)
The result was an index scan on the streams table instead of an index seek.

In this PR, all streamId parameters are typed as SqlDbType.Char with length 42 because the streamid column on the streams table is declared as CHAR(42).
Now an index seek can be done.



![image](https://user-images.githubusercontent.com/382499/47390581-094c9180-d718-11e8-993a-815ae554bf4e.png)

Before
![image](https://user-images.githubusercontent.com/382499/47390555-f89c1b80-d717-11e8-8155-15183b9ae920.png)

After
![image](https://user-images.githubusercontent.com/382499/47390533-f043e080-d717-11e8-82c3-bdc84b109b21.png)


