### PR TITLE
Bump HAL Server to rc3 for Http Tests

### DIFF
--- a/src/SqlStreamStore.Http.Tests/SqlStreamStore.Http.Tests.csproj
+++ b/src/SqlStreamStore.Http.Tests/SqlStreamStore.Http.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="SqlStreamStore.HAL" Version="1.0.0-rc2-*" />
+    <PackageReference Include="SqlStreamStore.HAL" Version="1.0.0-rc3.*" />
     <PackageReference Include="xunit.core" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/SqlStreamStore.Http/HttpClientSqlStreamStore.Delete.cs
+++ b/src/SqlStreamStore.Http/HttpClientSqlStreamStore.Delete.cs
@@ -63,8 +63,7 @@ namespace SqlStreamStore
                 null,
                 cancellationToken: cancellationToken);
 
-            ThrowOnError(client);
-            
+            ThrowOnError(client);            
         }
     }
 }

--- a/src/SqlStreamStore.Http/Internal/HoneyBearHalClient/HalClientExtensions.cs
+++ b/src/SqlStreamStore.Http/Internal/HoneyBearHalClient/HalClientExtensions.cs
@@ -37,7 +37,7 @@
             var current =
                 new[]
                 {
-                    (result.Content == null
+                    (result.Content.Headers.ContentLength == 0
                         ? new Resource()
                         : await result.Content.ReadResource())
                     .WithBaseAddress(new Uri(client.Client.HttpClient.BaseAddress, uri))


### PR DESCRIPTION
The CI Build of the HAL Server was pushing packages without any prerelease tag. This along with a bug in the server was causing the CI build of SqlStreamStore to fail. That has been fixed.