### PR TITLE
Empty artifacts directory. Fixes #195

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ dlldata.c
 
 # DNX
 project.lock.json
-artifacts/
 
 *_i.c
 *_p.c

--- a/artifacts/.gitignore
+++ b/artifacts/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Directory needs to exist so it can be mounted in container on a clean clone. Instead of creating the directory decided to add an empty one with a `.gitignore` for all files that are put there.

Fixes #195.