### PR TITLE
fix nowarn properties

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,7 @@
     <PackageLicenseUrl>https://github.com/SqlStreamStore/SqlStreamStore/blob/master/LICENSE</PackageLicenseUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cqrs;event-sourcing;event-store;stream-store</PackageTags>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
+    <NoWarn>$(NoWarn);1701;1702;1705;1591</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/LoadTests/LoadTests.csproj
+++ b/src/LoadTests/LoadTests.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64;ubuntu.16.10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
     <OutputType>exe</OutputType>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyConsoleStd" Version="1.1.0" />

--- a/src/SqlStreamStore.Http.Tests/SqlStreamStore.Http.Tests.csproj
+++ b/src/SqlStreamStore.Http.Tests/SqlStreamStore.Http.Tests.csproj
@@ -6,7 +6,6 @@
     <PackageId>SqlStreamStore.Http.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SqlStreamStore.Http/SqlStreamStore.Http.csproj
+++ b/src/SqlStreamStore.Http/SqlStreamStore.Http.csproj
@@ -7,7 +7,6 @@
     <AssemblyName>SqlStreamStore.Http</AssemblyName>
     <PackageId>SqlStreamStore.Http</PackageId>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />

--- a/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
+++ b/src/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
@@ -5,7 +5,7 @@
     <PackageId>SqlStreamStore.MsSql.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>1701;1702;1705;1591;CS0618</NoWarn>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" />

--- a/src/SqlStreamStore.MsSql.V3.Tests/SqlStreamStore.MsSql.V3.Tests.csproj
+++ b/src/SqlStreamStore.MsSql.V3.Tests/SqlStreamStore.MsSql.V3.Tests.csproj
@@ -5,7 +5,7 @@
     <PackageId>SqlStreamStore.MsSql.V3.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>1701;1702;1705;1591;CS0618</NoWarn>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" />

--- a/src/SqlStreamStore.MsSql/SqlStreamStore.MsSql.csproj
+++ b/src/SqlStreamStore.MsSql/SqlStreamStore.MsSql.csproj
@@ -7,7 +7,6 @@
     <AssemblyName>SqlStreamStore.MsSql</AssemblyName>
     <PackageId>SqlStreamStore.MsSql</PackageId>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
+++ b/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
@@ -6,7 +6,6 @@
     <PackageId>SqlStreamStore.Postgres.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" />

--- a/src/SqlStreamStore.Postgres/SqlStreamStore.Postgres.csproj
+++ b/src/SqlStreamStore.Postgres/SqlStreamStore.Postgres.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>SqlStreamStore.Postgres</AssemblyName>
     <PackageId>SqlStreamStore.Postgres</PackageId>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
     <LangVersion>latest</LangVersion>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>

--- a/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
+++ b/src/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
@@ -4,7 +4,6 @@
     <DebugType>portable</DebugType>
     <AssemblyName>SqlStreamStore.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
     <RootNamespace>SqlStreamStore</RootNamespace>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
- most of the properties in the projects are redundant
- those that are required should inherit from the current value set in `Directory.Build.props`
- similarly, the property set in `Directory.Build.props` should inherit from the current value