### PR TITLE
don't publish without running tests

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -56,7 +56,7 @@ namespace build
                     "SqlStreamStore.Http"),
                 project => Run("dotnet", $"pack src/{project}/{project}.csproj -c Release -o ../../{ArtifactsDir} --no-build --version-suffix {versionSuffix}"));
 
-            Target(Publish, DependsOn(Pack), () =>
+            Target(Publish, DependsOn(Pack, RunTests), () =>
             {
                 var packagesToPush = Directory.GetFiles(ArtifactsDir, "*.nupkg", SearchOption.TopDirectoryOnly);
                 Console.WriteLine($"Found packages to publish: {string.Join("; ", packagesToPush)}");
@@ -75,7 +75,7 @@ namespace build
                 }
             });
 
-            Target("default", DependsOn(Clean, RunTests, Publish));
+            Target("default", DependsOn(Clean, Publish));
 
             RunTargets(args);
         }


### PR DESCRIPTION
Unless you don't mind publishing without running the tests first?

Assuming publishing should only happen after running the tests, it should not be the responsibility of the `default` target to set up this dependency via it's own dependencies, which also requires declaring those dependencies in the right order. Rather, the `publish` task should declare the dependency.

I guess you may want to manually run `publish` locally on it's own, having run the tests earlier, but in that case, you wouldn't want to rebuild either, so the correct way to run that is with `./build.cmd -s publish` or `./build.sh -s publish` (`-s` is shorthand for `--skip-dependencies`).