### PR TITLE
In tests, ensure databases have compatibility level set to 110 (SqlServer 2012)

### DIFF
--- a/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
+++ b/src/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreFixture.cs
@@ -19,7 +19,7 @@ namespace SqlStreamStore
         {
             _schema = schema;
             _deleteDatabaseOnDispose = deleteDatabaseOnDispose;
-            DatabaseName = $"StreamStoreTests-{Guid.NewGuid():n}";
+            DatabaseName = $"sss-v2-{Guid.NewGuid():n}";
             _databaseInstance = new DockerSqlServerDatabase(DatabaseName);
 
             ConnectionString = CreateConnectionString();
@@ -168,7 +168,13 @@ namespace SqlStreamStore
                 using(var connection = CreateConnection())
                 {
                     await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
-                    using (var command = new SqlCommand($"CREATE DATABASE [{_databaseName}]", connection))
+
+                    var createCommand = $@"CREATE DATABASE [{_databaseName}]
+ALTER DATABASE [{_databaseName}] SET SINGLE_USER
+ALTER DATABASE [{_databaseName}] SET COMPATIBILITY_LEVEL=110
+ALTER DATABASE [{_databaseName}] SET MULTI_USER";
+
+                    using (var command = new SqlCommand(createCommand, connection))
                     {
                         await command.ExecuteNonQueryAsync(cancellationToken).NotOnCapturedContext();
                     }

--- a/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
+++ b/src/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3Fixture.cs
@@ -27,7 +27,7 @@ namespace SqlStreamStore
             _disableDeletionTracking = disableDeletionTracking;
             _databaseNameOverride = databaseNameOverride;
             _deleteDatabaseOnDispose = deleteDatabaseOnDispose;
-            _databaseName = databaseNameOverride ?? $"StreamStoreTests-{Guid.NewGuid():n}";
+            _databaseName = databaseNameOverride ?? $"sss-v3-{Guid.NewGuid():n}";
             _databaseInstance = new DockerSqlServerDatabase(_databaseName);
 
             ConnectionString = CreateConnectionString();
@@ -167,7 +167,13 @@ namespace SqlStreamStore
                 using(var connection = CreateConnection())
                 {
                     await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
-                    using (var command = new SqlCommand($"CREATE DATABASE [{_databaseName}]", connection))
+
+                    var createCommand = $@"CREATE DATABASE [{_databaseName}]
+ALTER DATABASE [{_databaseName}] SET SINGLE_USER
+ALTER DATABASE [{_databaseName}] SET COMPATIBILITY_LEVEL=110
+ALTER DATABASE [{_databaseName}] SET MULTI_USER";
+
+                    using (var command = new SqlCommand(createCommand, connection))
                     {
                         await command.ExecuteNonQueryAsync(cancellationToken).NotOnCapturedContext();
                     }


### PR DESCRIPTION
Ensures no features creep in that require later versions without appropriate change control.