### PR TITLE
reformat build scripts to have an option per line

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,5 +2,6 @@ docker build --tag sss-build .
 docker run --rm --name sss-build ^
  -v /var/run/docker.sock:/var/run/docker.sock ^
  -v %cd%/artifacts:/artifacts ^
- --network host sss-build ^
+ --network host ^
+ sss-build ^
  dotnet run -p /build/build.csproj -- %*

--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,6 @@ docker run --rm --name sss-build \
  -v $PWD/artifacts:/artifacts \
  --network host \
  -e TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER \
- -e MYGET_API_KEY=$MYGET_API_KEY sss-build \
+ -e MYGET_API_KEY=$MYGET_API_KEY \
+ sss-build \
  dotnet run -p /build/build.csproj -- "$@"


### PR DESCRIPTION
Just makes it a bit clearer. Being a Docker noob, I was confused at first. I thought `--network` had two arguments in `build.cmd` and only one in `build.sh`, until I spotted `sss-build` at the end of the second `-e` line in `build.sh`.