### PR TITLE
Test projects target netcoreapp2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.402-sdk-alpine3.7 AS build
+FROM microsoft/dotnet:2.2.100-sdk-alpine3.8 AS build
 
 RUN apk add libcurl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM microsoft/dotnet:2.2.100-sdk-stretch AS build
 
-RUN apk add libcurl
-
 WORKDIR /repo
 
 # https://github.com/moby/moby/issues/15858

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2.100-sdk-alpine3.8 AS build
+FROM microsoft/dotnet:2.2.100-sdk-stretch AS build
 
 RUN apk add libcurl
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <NoWarn>$(NoWarn);1701;1702;1705;1591</NoWarn>
+    <NoWarn>$(NoWarn);1701;1702;1705;1591;CS0618</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/tests/LoadTests/LoadTests.csproj
+++ b/tests/LoadTests/LoadTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64;ubuntu.16.10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
     <OutputType>exe</OutputType>
   </PropertyGroup>

--- a/tests/SqlStreamStore.Http.Tests/SqlStreamStore.Http.Tests.csproj
+++ b/tests/SqlStreamStore.Http.Tests/SqlStreamStore.Http.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>SqlStreamStore.Http.Tests</AssemblyName>
     <PackageId>SqlStreamStore.Http.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
   </PropertyGroup>
 

--- a/tests/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
+++ b/tests/SqlStreamStore.MsSql.Tests/SqlStreamStore.MsSql.Tests.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>SqlStreamStore.MsSql.Tests</AssemblyName>
     <PackageId>SqlStreamStore.MsSql.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs"

--- a/tests/SqlStreamStore.MsSql.V3.Tests/SqlStreamStore.MsSql.V3.Tests.csproj
+++ b/tests/SqlStreamStore.MsSql.V3.Tests/SqlStreamStore.MsSql.V3.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>SqlStreamStore.MsSql.V3.Tests</AssemblyName>
     <PackageId>SqlStreamStore.MsSql.V3.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>

--- a/tests/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
+++ b/tests/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <AssemblyName>SqlStreamStore.Postgres.Tests</AssemblyName>
-    <PackageId>SqlStreamStore.Postgres.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/SqlStreamStore.TestUtils/SqlStreamStore.TestUtils.csproj
+++ b/tests/SqlStreamStore.TestUtils/SqlStreamStore.TestUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>SqlStreamStore</RootNamespace>
   </PropertyGroup>
 

--- a/tests/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
+++ b/tests/SqlStreamStore.Tests/SqlStreamStore.Tests.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <DebugType>portable</DebugType>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <AssemblyName>SqlStreamStore.Tests</AssemblyName>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SqlStreamStore.AcceptanceTests\*.cs" LinkBase="InMemory" />


### PR DESCRIPTION
 - Test projects target netcoreapp2.2 
 - Use microsoft/dotnet:2.2.100-sdk-stretch container for builds.
 - Some cleanup in the csprojs