### PR TITLE
Fix Broken Subscriptions Tests

### DIFF
--- a/tests/SqlStreamStore.TestUtils/TaskExtensions.cs
+++ b/tests/SqlStreamStore.TestUtils/TaskExtensions.cs
@@ -5,25 +5,15 @@ namespace SqlStreamStore
 {
     public static class TaskExtensions
     {
-        public static async Task<T> WithTimeout<T>(this Task<T> task, int timeout = 3000)
-        {
-            if(await Task.WhenAny(task, Task.Delay(timeout)) == task)
-            {
-                return await task;
-            }
-
-            throw new TimeoutException("Timed out waiting for task");
-        }
+        public static async Task<T> WithTimeout<T>(this Task<T> task, int timeout = 3000) =>
+            await Task.WhenAny(task, Task.Delay(timeout)) == task
+                ? task.Result
+                : throw new TimeoutException("Timed out waiting for task");
 
         public static async Task WithTimeout(this Task task, int timeout = 3000)
         {
-            if(await Task.WhenAny(task, Task.Delay(timeout)) == task)
-            {
-                await task;
-                return;
-            }
-
-            throw new TimeoutException("Timed out waiting for task");
+            if(await Task.WhenAny(task, Task.Delay(timeout)) != task)
+                throw new TimeoutException("Timed out waiting for task");
         }
     }
 }


### PR DESCRIPTION
AsyncAutoResetEvent.WaitAsync should return immediately after AsyncAutoResetEvent.Set, so these tests were not testing Dispose during the handling of a message.

Also, increasing the timeout made these tests far more likely to pass

(cherry picked from commit 88876e01ef45b1b62f3393eaa10261cd6a3ae56d)