### PR TITLE
Fix Verbose Output on Tests

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -37,12 +37,12 @@ namespace build
                 }
             });
 
-            Target(Build, () => Run("dotnet", "build SqlStreamStore.sln -c Release"));
+            Target(Build, () => Run("dotnet", "build --configuration=Release"));
 
             Target(
                 RunTests,
                 DependsOn(Build),
-                project => Run("dotnet", "test -c Release --verbosity=normal"));
+                project => Run("dotnet", "test --configuration=Release --no-build --no-restore --verbosity=normal"));
 
             Target(
                 Pack,

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -42,7 +42,7 @@ namespace build
             Target(
                 RunTests,
                 DependsOn(Build),
-                project => Run("dotnet", "test --configuration=Release --no-build --no-restore --verbosity=normal"));
+                () => Run("dotnet", "test --configuration=Release --no-build --no-restore --verbosity=normal"));
 
             Target(
                 Pack,
@@ -74,7 +74,7 @@ namespace build
                 }
             });
 
-            Target("default", DependsOn(Build, RunTests, Publish));
+            Target("default", DependsOn(RunTests, Publish));
 
             RunTargetsAndExit(args);
         }

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -74,7 +74,7 @@ namespace build
                 }
             });
 
-            Target("default", DependsOn(RunTests, Publish));
+            Target("default", DependsOn(Build, RunTests, Publish));
 
             RunTargetsAndExit(args);
         }


### PR DESCRIPTION
`dotnet test --verbosity=normal` is required to see decent test output. It also means we get a lot of output from compilation that we don't care about. Since compilation happens in the previous target anyway this should be fine.