### PR TITLE
MSSQL: Better performance when handling large json payloads

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadAll.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadAll.cs
@@ -2,6 +2,7 @@ namespace SqlStreamStore
 {
     using System;
     using System.Collections.Generic;
+    using System.Data;
     using System.Data.SqlClient;
     using System.Linq;
     using System.Threading;
@@ -31,7 +32,7 @@ namespace SqlStreamStore
                     command.Parameters.AddWithValue("position", position);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not
                     var reader = await command
-                        .ExecuteReaderAsync(cancellationToken)
+                        .ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken)
                         .NotOnCapturedContext();
 
                     List<StreamMessage> messages = new List<StreamMessage>();
@@ -65,7 +66,7 @@ namespace SqlStreamStore
                             Func<CancellationToken, Task<string>> getJsonData;
                             if(prefetch)
                             {
-                                var jsonData = reader.GetString(7);
+                                var jsonData = await reader.GetTextReader(7).ReadToEndAsync();
                                 getJsonData = _ => Task.FromResult(jsonData);
                             }
                             else
@@ -128,14 +129,14 @@ namespace SqlStreamStore
                     command.Parameters.AddWithValue("position", position);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not
                     var reader = await command
-                        .ExecuteReaderAsync(cancellationToken)
+                        .ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken)
                         .NotOnCapturedContext();
 
                     List<StreamMessage> messages = new List<StreamMessage>();
                     if (!reader.HasRows)
                     {
                         // When reading backwards and there are no more items, then next position is LongPosition.Start,
-                        // regardles of what the fromPosition is.
+                        // regardless of what the fromPosition is.
                         return new ReadAllPage(
                             Position.Start,
                             Position.Start,
@@ -159,7 +160,7 @@ namespace SqlStreamStore
                         Func<CancellationToken, Task<string>> getJsonData;
                         if (prefetch)
                         {
-                            var jsonData = reader.GetString(7);
+                            var jsonData = await reader.GetTextReader(7).ReadToEndAsync();
                             getJsonData = _ => Task.FromResult(jsonData);
                         }
                         else

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
@@ -112,7 +112,9 @@
                 command.Parameters.AddWithValue("count", count + 1); //Read extra row to see if at end or not
                 command.Parameters.AddWithValue("streamVersion", streamVersion);
 
-                using(var reader = await command.ExecuteReaderAsync(cancellationToken).NotOnCapturedContext())
+                using(var reader = await command
+                    .ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken)
+                    .NotOnCapturedContext())
                 {
                     await reader.ReadAsync(cancellationToken).NotOnCapturedContext();
                     if(reader.IsDBNull(0))
@@ -151,7 +153,7 @@
                             Func<CancellationToken, Task<string>> getJsonData;
                             if(prefetch)
                             {
-                                var jsonData = reader.GetString(6);
+                                var jsonData = await reader.GetTextReader(6).ReadToEndAsync();
                                 getJsonData = _ => Task.FromResult(jsonData);
                             }
                             else
@@ -205,7 +207,8 @@
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamId });
                     command.Parameters.AddWithValue("streamVersion", streamVersion);
 
-                    var jsonData = (string)await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
+                    var jsonData = (string)await command
+                        .ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
                     return jsonData;
                 }
             }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
@@ -217,7 +217,7 @@
                         {
                             return await reader.GetTextReader(0).ReadToEndAsync();
                         }
-                        return string.Empty;
+                        return null;
                     }
                 }
             }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
@@ -207,9 +207,18 @@
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamId });
                     command.Parameters.AddWithValue("streamVersion", streamVersion);
 
-                    var jsonData = (string)await command
-                        .ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
-                    return jsonData;
+                    using(var reader = await command
+                        .ExecuteReaderAsync(
+                            CommandBehavior.SequentialAccess | CommandBehavior.SingleRow, 
+                            cancellationToken)
+                        .NotOnCapturedContext())
+                    {
+                        if(await reader.ReadAsync(cancellationToken).NotOnCapturedContext())
+                        {
+                            return await reader.GetTextReader(0).ReadToEndAsync();
+                        }
+                        return string.Empty;
+                    }
                 }
             }
         }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
@@ -106,7 +106,9 @@
                 command.Parameters.AddWithValue("count", count + 1); //Read extra row to see if at end or not
                 command.Parameters.AddWithValue("streamVersion", streamVersion);
 
-                using(var reader = await command.ExecuteReaderAsync(cancellationToken).NotOnCapturedContext())
+                using(var reader = await command
+                    .ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken)
+                    .NotOnCapturedContext())
                 {
                     await reader.ReadAsync(cancellationToken).NotOnCapturedContext();
                     if(reader.IsDBNull(0))
@@ -149,7 +151,7 @@
                             Func<CancellationToken, Task<string>> getJsonData;
                             if(prefetch)
                             {
-                                var jsonData = reader.GetString(ordinal);
+                                var jsonData = await reader.GetTextReader(ordinal).ReadToEndAsync();
                                 getJsonData = _ => Task.FromResult(jsonData);
                             }
                             else
@@ -198,16 +200,26 @@
 
         private async Task<string> GetJsonData(string streamId, int streamVersion, CancellationToken cancellationToken)
         {
-            using(var connection = _createConnection())
+            using (var connection = _createConnection())
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
-                using(var command = new SqlCommand(_scripts.ReadMessageData, connection))
+                using (var command = new SqlCommand(_scripts.ReadMessageData, connection))
                 {
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamId });
                     command.Parameters.AddWithValue("streamVersion", streamVersion);
 
-                    var jsonData = (string)await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
-                    return jsonData;
+                    using (var reader = await command
+                        .ExecuteReaderAsync(
+                            CommandBehavior.SequentialAccess | CommandBehavior.SingleRow,
+                            cancellationToken)
+                        .NotOnCapturedContext())
+                    {
+                        if (await reader.ReadAsync(cancellationToken).NotOnCapturedContext())
+                        {
+                            return await reader.GetTextReader(0).ReadToEndAsync();
+                        }
+                        return string.Empty;
+                    }
                 }
             }
         }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
@@ -218,7 +218,7 @@
                         {
                             return await reader.GetTextReader(0).ReadToEndAsync();
                         }
-                        return string.Empty;
+                        return null;
                     }
                 }
             }

--- a/tests/LoadTests/AppendExpectedVersionAnyParallel.cs
+++ b/tests/LoadTests/AppendExpectedVersionAnyParallel.cs
@@ -44,7 +44,7 @@
             int numberOfMessagesToWrite = Input.ReadInt(
                 $"Number message to append: ", 1, 10000000);
 
-            int messageJsonDataSize = Input.ReadInt("Size of Json (bytes): ", 1, 1024 * 1024);
+            int messageJsonDataSize = Input.ReadInt("Size of Json (bytes): ", 1, 10 * 1024 * 1024);
 
             int numberOfMessagesPerAmend = Input.ReadInt("Number of messages per append: ", 1, 1000);
 

--- a/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadAll.cs
+++ b/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadAll.cs
@@ -12,7 +12,6 @@
         [Fact, Trait("Category", "ReadAll")]
         public async Task Can_read_all_forwards()
         {
-            
             await store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
             await store.AppendToStream("stream-2", ExpectedVersion.NoStream, CreateNewStreamMessages(4, 5, 6));
             var expectedMessages = new[]
@@ -56,26 +55,20 @@
             }
         }
 
-        /*[Fact, Trait("Category", "ReadAll")]
+        [Fact, Trait("Category", "ReadAll")]
         public async Task Can_read_all_forwards_without_prefetch()
         {
-            using (var fixture = GetFixture())
+            await store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+
+            var page = await store.ReadAllForwards(Position.Start, 4, prefetchJsonData: false);
+
+            foreach(var streamMessage in page.Messages)
             {
-                using (var store = await fixture.GetStreamStore())
-                {
-                    await store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+                streamMessage.GetJsonData().IsCompleted.ShouldBeFalse();
 
-                    var page = await store.ReadAllForwards(Position.Start, 4, prefetchJsonData: false);
-
-                    foreach(var streamMessage in page.Messages)
-                    {
-                        streamMessage.GetJsonData().IsCompleted.ShouldBeFalse();
-
-                        (await streamMessage.GetJsonData()).ShouldNotBeNullOrWhiteSpace();
-                    }
-                }
+                (await streamMessage.GetJsonData()).ShouldNotBeNullOrWhiteSpace();
             }
-        }*/
+        }
 
         [Fact, Trait("Category", "ReadAll")]
         public async Task When_read_without_prefetch_and_stream_is_deleted_then_GetJsonData_should_return_null()

--- a/tests/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreAcceptanceTests.cs
+++ b/tests/SqlStreamStore.MsSql.Tests/MsSqlStreamStoreAcceptanceTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace SqlStreamStore
 {
     using System;
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using Shouldly;
     using SqlStreamStore.Streams;
@@ -141,5 +142,21 @@
             var sqlScript = store.GetSchemaCreationScript();
             sqlScript.ShouldBe(new ScriptsV2.Scripts("custom_schema").CreateSchema);
         }
+
+        [Fact]
+        public async Task Time_taken_to_append_and_read_large_message()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var streamId = "stream-large";
+            var data = new string('a', 1024 * 1024 * 2);
+            var newStreamMessage = new NewStreamMessage(Guid.NewGuid(), "foo", data);
+            await fixture.Store.AppendToStream(streamId, ExpectedVersion.Any, newStreamMessage);
+            TestOutputHelper.WriteLine($"Append: {stopwatch.Elapsed}");
+
+            stopwatch.Restart();
+            var readStreamPage = await fixture.Store.ReadStreamForwards(streamId, StreamVersion.Start, 1);
+            var jsonData = await readStreamPage.Messages[0].GetJsonData();
+            TestOutputHelper.WriteLine($"Read: {stopwatch.Elapsed}");
+        } 
     }
 }

--- a/tests/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3AcceptanceTests.cs
+++ b/tests/SqlStreamStore.MsSql.V3.Tests/MsSqlStreamStoreV3AcceptanceTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace SqlStreamStore
 {
+    using System;
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using Shouldly;
     using SqlStreamStore.Streams;
@@ -96,6 +98,38 @@
 
             var sqlScript = store.GetSchemaCreationScript();
             sqlScript.ShouldBe(new ScriptsV3.Scripts("custom_schema").CreateSchema);
+        }
+
+        [Fact]
+        public async Task Time_taken_to_append_and_read_large_message()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var streamId = "stream-large";
+            var data = new string('a', 1024 * 1024 * 2);
+            var newStreamMessage = new NewStreamMessage(Guid.NewGuid(), "foo", data);
+            await fixture.Store.AppendToStream(streamId, ExpectedVersion.Any, newStreamMessage);
+            TestOutputHelper.WriteLine($"Append: {stopwatch.Elapsed}");
+
+            stopwatch.Restart();
+            var readStreamPage = await fixture.Store.ReadStreamForwards(streamId, StreamVersion.Start, 1);
+            var jsonData = await readStreamPage.Messages[0].GetJsonData();
+            TestOutputHelper.WriteLine($"Read: {stopwatch.Elapsed}");
+        }
+
+        [Fact]
+        public async Task Time_taken_to_append_and_read_large_message_without_prefetch()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var streamId = "stream-large";
+            var data = new string('a', 1024 * 1024 * 2);
+            var newStreamMessage = new NewStreamMessage(Guid.NewGuid(), "foo", data);
+            await fixture.Store.AppendToStream(streamId, ExpectedVersion.Any, newStreamMessage);
+            TestOutputHelper.WriteLine($"Append: {stopwatch.Elapsed}");
+
+            stopwatch.Restart();
+            var readStreamPage = await fixture.Store.ReadStreamForwards(streamId, StreamVersion.Start, prefetchJsonData: false, maxCount: 1);
+            var jsonData = await readStreamPage.Messages[0].GetJsonData();
+            TestOutputHelper.WriteLine($"Read: {stopwatch.Elapsed}");
         }
     }
 }


### PR DESCRIPTION
MsSql & MsSql v3: Using CommandBehaviour.Sequential and GetTextReader improves the performance of reading of larger json data messages.

Thanks to @cristiango