### PR TITLE
Fix For Edge Case in ExpectedVersion

### DIFF
--- a/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/AppendToStream.sql
@@ -83,6 +83,15 @@ BEGIN
   FROM __schema__.streams
   WHERE __schema__.streams.id = _stream_id;
 
+  IF (_expected_version >= 0 AND (
+                                   SELECT __schema__.streams.version
+                                   FROM __schema__.streams
+                                   WHERE __schema__.streams.id_internal = _stream_id_internal
+                                 ) < _expected_version)
+  THEN
+    RAISE EXCEPTION 'WrongExpectedVersion';
+  END IF;
+
   IF (_expected_version >= 0 AND _stream_id_internal IS NULL)
   THEN
     RAISE EXCEPTION 'WrongExpectedVersion';

--- a/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.AppendStream.cs
+++ b/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.AppendStream.cs
@@ -650,5 +650,19 @@
             result2.CurrentVersion.ShouldBe(2);
             result2.CurrentPosition.ShouldBeGreaterThanOrEqualTo(result1.CurrentPosition + 2L);
         }
+
+        [Fact, Trait("Category", "AppendStream")]
+        public async Task When_append_stream_with_higher_wrong_expected_version_then_should_throw()
+        {
+            const string streamId = "stream-1";
+            await store
+                .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+
+            var exception = await Record.ExceptionAsync(() =>
+                store.AppendToStream(streamId, 10, CreateNewStreamMessages(4)));
+
+            exception.ShouldBeOfType<WrongExpectedVersionException>(
+                ErrorMessages.AppendFailedWrongExpectedVersion(streamId, 10));
+        }
     }
 }


### PR DESCRIPTION
Example of issue: Caller sends messages at ExpectedVersion: 0,1,2 then sends 10