### PR TITLE
switch to PackageLicenseExpression

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Damian Hickey</Authors>
     <PackageProjectUrl>https://github.com/SqlStreamStore/SqlStreamStore</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/SqlStreamStore/SqlStreamStore/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cqrs;event-sourcing;event-store;stream-store</PackageTags>
     <NoWarn>$(NoWarn);1701;1702;1705;1591;NU5105</NoWarn>


### PR DESCRIPTION
gets rid of multiple instances of:

> warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.