### PR TITLE
Native JSON in Postgres

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 docker build --tag sss-build .
-docker run --rm --name sss-build ^
+docker run --rm -it --name sss-build ^
  -v /var/run/docker.sock:/var/run/docker.sock ^
  -v %cd%/artifacts:/artifacts ^
  -v %cd%/.git:/.git ^

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 docker build --tag sss-build .
-docker run --rm --name sss-build \
+docker run --rm -it --name sss-build \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v $PWD/artifacts:/artifacts \
  -v $PWD/.git:/.git \

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/ReadAll.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/ReadAll.sql
@@ -11,8 +11,8 @@ CREATE OR REPLACE FUNCTION __schema__.read_all(
     "position"     BIGINT,
     create_utc     TIMESTAMP,
     "type"         VARCHAR(128),
-    json_metadata  VARCHAR,
-    json_data      VARCHAR,
+    json_metadata  JSONB,
+    json_data      JSONB,
     max_age        INT
   )
 AS $F$

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/Tables.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/Tables.sql
@@ -37,8 +37,8 @@ CREATE TABLE IF NOT EXISTS __schema__.messages (
   message_id         UUID         NOT NULL,
   created_utc        TIMESTAMP    NOT NULL,
   type               VARCHAR(128) NOT NULL,
-  json_data          VARCHAR      NOT NULL,
-  json_metadata      VARCHAR,
+  json_data          JSONB      NOT NULL,
+  json_metadata      JSONB,
   CONSTRAINT pk_messages PRIMARY KEY (position),
   CONSTRAINT fk_messages_stream FOREIGN KEY (stream_id_internal) REFERENCES __schema__.streams (id_internal),
   CONSTRAINT uq_messages_stream_id_internal_and_stream_version UNIQUE (stream_id_internal, stream_version),
@@ -54,8 +54,8 @@ BEGIN
   CREATE TYPE __schema__.new_stream_message AS (
     message_id    UUID,
     "type"        VARCHAR(128),
-    json_data     VARCHAR,
-    json_metadata VARCHAR);
+    json_data     JSONB,
+    json_metadata JSONB);
   EXCEPTION
   WHEN duplicate_object
     THEN null;

--- a/src/SqlStreamStore.Postgres/PostgresNewStreamMessage.cs
+++ b/src/SqlStreamStore.Postgres/PostgresNewStreamMessage.cs
@@ -16,7 +16,7 @@
                 MessageId = message.MessageId,
                 Type = message.Type,
                 JsonData = message.JsonData,
-                JsonMetadata = message.JsonMetadata
+                JsonMetadata = string.IsNullOrEmpty(message.JsonMetadata) ? null : message.JsonMetadata,
             };
     }
 }


### PR DESCRIPTION
As discussed in #250

I had to make a minor change in the Postgres NewStreamMessage type as it was being fed an empty string, which is invalid JSON, which made Postgres crash. This small change is backwards compatible with the non-JSONB Postgres schema.

The alternative is fixing that in the original type, which I did in https://github.com/elevate/SQLStreamStore/commit/c112d426129e0ae8e0d0b88eda5bc8ed72b278b7 but that affected the MSSQL implementation so I had to patch things there, and I'd rather not do that. Up to you.
