### PR TITLE
[WIP] Catch any Inner OperationCancelledException

### DIFF
--- a/src/SqlStreamStore/ExceptionExtensions.cs
+++ b/src/SqlStreamStore/ExceptionExtensions.cs
@@ -1,0 +1,10 @@
+namespace SqlStreamStore
+{
+    using System;
+
+    internal static class ExceptionExtensions
+    {
+        public static bool IsOperationCancelledException(this Exception ex)
+            => ex is OperationCanceledException || (ex.InnerException?.IsOperationCancelledException() ?? false);
+    }
+}

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -159,7 +159,7 @@
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex.IsOperationCancelledException())
             {
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;
@@ -190,7 +190,7 @@
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex.IsOperationCancelledException())
             {
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -172,7 +172,7 @@
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex.IsOperationCancelledException())
             {
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;
@@ -203,7 +203,7 @@
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex.IsOperationCancelledException())
             {
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
                 throw;


### PR DESCRIPTION
Some libraries (e.g. System.Data) will wrap OperationCancelledException with their own. So, unwrap them.