### PR TITLE
Add 'AddSqlStreamStoreHal' Extension Method

### DIFF
--- a/src/SqlStreamStore.HAL.DevServer/DevServerStartup.cs
+++ b/src/SqlStreamStore.HAL.DevServer/DevServerStartup.cs
@@ -27,7 +27,7 @@
 
         public IServiceProvider ConfigureServices(IServiceCollection services) => services
             .AddResponseCompression(options => options.MimeTypes = new[] { "application/hal+json" })
-            .AddRouting()
+            .AddSqlStreamStoreHal()
             .BuildServiceProvider();
 
         public void Configure(IApplicationBuilder app) => app

--- a/src/SqlStreamStore.HAL/SqlStreamStoreHalMiddleware.cs
+++ b/src/SqlStreamStore.HAL/SqlStreamStoreHalMiddleware.cs
@@ -7,6 +7,7 @@
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.DependencyInjection;
     using SqlStreamStore.HAL.AllStream;
     using SqlStreamStore.HAL.AllStreamMessage;
     using SqlStreamStore.HAL.Docs;
@@ -95,6 +96,15 @@
                     .MapMiddlewareRoute($"{Constants.Paths.Streams}/{{streamId}}/{{p}}",
                         inner => inner.UseStreamMessages(streamMessages))
                     .MapMiddlewareRoute(string.Empty, inner => inner.UseIndex(index)));
+
+        public static IServiceCollection AddSqlStreamStoreHal(this IServiceCollection serviceCollection)
+        {
+            if(serviceCollection == null)
+            {
+                throw new ArgumentNullException(nameof(serviceCollection));
+            }
+
+            return serviceCollection.AddRouting();
         }
 
         private class OptionalHeadRequestWrapper : IDisposable

--- a/src/SqlStreamStore.HAL/SqlStreamStoreHalMiddleware.cs
+++ b/src/SqlStreamStore.HAL/SqlStreamStoreHalMiddleware.cs
@@ -85,17 +85,31 @@
                 .Use(Rfc1738)
                 .Use(HeadRequests)
                 .UseRouter(router => router
-                    .MapMiddlewareRoute($"{Constants.Paths.Docs}/{{doc}}", inner => inner.UseDocs(documentation))
-                    .MapMiddlewareRoute(Constants.Paths.AllStream, inner => inner.UseAllStream(allStream))
-                    .MapMiddlewareRoute($"{Constants.Paths.AllStream}/{{position:long}}",
+                    .MapMiddlewareRoute(
+                        $"{Constants.Paths.Docs}/{{doc}}",
+                        inner => inner.UseDocs(documentation))
+                    .MapMiddlewareRoute(
+                        Constants.Paths.AllStream,
+                        inner => inner.UseAllStream(allStream))
+                    .MapMiddlewareRoute(
+                        $"{Constants.Paths.AllStream}/{{position:long}}",
                         inner => inner.UseAllStreamMessage(allStreamMessages))
-                    .MapMiddlewareRoute(Constants.Paths.Streams, inner => inner.UseStreamBrowser(streamBrowser))
-                    .MapMiddlewareRoute($"{Constants.Paths.Streams}/{{streamId}}", inner => inner.UseStreams(streams))
-                    .MapMiddlewareRoute($"{Constants.Paths.Streams}/{{streamId}}/{Constants.Paths.Metadata}",
+                    .MapMiddlewareRoute(
+                        Constants.Paths.Streams,
+                        inner => inner.UseStreamBrowser(streamBrowser))
+                    .MapMiddlewareRoute(
+                        $"{Constants.Paths.Streams}/{{streamId}}",
+                        inner => inner.UseStreams(streams))
+                    .MapMiddlewareRoute(
+                        $"{Constants.Paths.Streams}/{{streamId}}/{Constants.Paths.Metadata}",
                         inner => inner.UseStreamMetadata(streamMetadata))
-                    .MapMiddlewareRoute($"{Constants.Paths.Streams}/{{streamId}}/{{p}}",
+                    .MapMiddlewareRoute(
+                        $"{Constants.Paths.Streams}/{{streamId}}/{{p}}",
                         inner => inner.UseStreamMessages(streamMessages))
-                    .MapMiddlewareRoute(string.Empty, inner => inner.UseIndex(index)));
+                    .MapMiddlewareRoute(
+                        string.Empty,
+                        inner => inner.UseIndex(index)));
+        }
 
         public static IServiceCollection AddSqlStreamStoreHal(this IServiceCollection serviceCollection)
         {

--- a/tests/SqlStreamStore.HAL.Tests/TestStartup.cs
+++ b/tests/SqlStreamStore.HAL.Tests/TestStartup.cs
@@ -19,7 +19,7 @@
 
         public IServiceProvider ConfigureServices(IServiceCollection services) 
             => services
-                .AddRouting()
+                .AddSqlStreamStoreHal()
                 .BuildServiceProvider();
 
         public void Configure(IApplicationBuilder app) => app

--- a/tests/SqlStreamStore.Http.Tests/HttpClientStreamStoreFixture.cs
+++ b/tests/SqlStreamStore.Http.Tests/HttpClientStreamStoreFixture.cs
@@ -5,7 +5,6 @@ namespace SqlStreamStore
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
-    using Microsoft.Extensions.DependencyInjection;
     using SqlStreamStore.HAL;
     using SqlStreamStore.Infrastructure;
 
@@ -24,8 +23,8 @@ namespace SqlStreamStore
             var basePath = $"/{string.Join("/", segments)}";
 
             var webHostBuilder = new WebHostBuilder()
-                .Configure(builder => builder.Map(basePath, inner => inner.UseSqlStreamStoreHal(_inMemoryStreamStore)))
-                .ConfigureServices(services => services.AddRouting());
+                .ConfigureServices(services => services.AddSqlStreamStoreHal())
+                .Configure(builder => builder.Map(basePath, inner => inner.UseSqlStreamStoreHal(_inMemoryStreamStore)));
 
             _server = new TestServer(webHostBuilder);
 


### PR DESCRIPTION
This way consumers do not need to know what dependencies to add to the service collection.