### PR TITLE
Fix Race Condition When Disposing MySqlDatabaseManager

### DIFF
--- a/tests/SqlStreamStore.TestUtils/MySql/MySqlDatabaseManager.cs
+++ b/tests/SqlStreamStore.TestUtils/MySql/MySqlDatabaseManager.cs
@@ -93,16 +93,22 @@ namespace SqlStreamStore.MySql
                                 command.ExecuteNonQuery();
                             }
                         }
-                        catch(MySqlException ex) when(ex.Number == 1094) // unknown thread id. means there is nothing to do
-                        {
-                        }
+                        catch(MySqlException ex) when(ex.Number == 1094
+                        ) // unknown thread id. means there is nothing to do
+                        { }
                     }
                 }
+            }
+            catch(MySqlException ex)
+            {
+                TestOutputHelper.WriteLine(
+                    $@"Attempted to execute ""{$"DROP DATABASE {DatabaseName}"}"" but failed. Number: {ex.Number}; SqlState: {ex.SqlState} {ex}");
+                throw;
             }
             catch(Exception ex)
             {
                 TestOutputHelper.WriteLine(
-                    $@"Attempted to execute ""{$"DROP DATABASE {DatabaseName}"}"" but failed: {ex}");
+                    $@"Attempted to execute ""{$"DROP DATABASE {DatabaseName}"}"" but failed. {ex}");
                 throw;
             }
         }

--- a/tests/SqlStreamStore.TestUtils/MySql/MySqlDatabaseManager.cs
+++ b/tests/SqlStreamStore.TestUtils/MySql/MySqlDatabaseManager.cs
@@ -86,11 +86,17 @@ namespace SqlStreamStore.MySql
 
                     foreach(var processId in processIds)
                     {
-                        using(var command = new MySqlCommand($"KILL {processId}", connection))
+                        try
                         {
-                            command.ExecuteNonQuery();
+                            using(var command = new MySqlCommand($"KILL {processId}", connection))
+                            {
+                                command.ExecuteNonQuery();
+                            }
                         }
-                    }                        
+                        catch(MySqlException ex) when(ex.Number == 1094) // unknown thread id. means there is nothing to do
+                        {
+                        }
+                    }
                 }
             }
             catch(Exception ex)


### PR DESCRIPTION
ignoring condition where we find a process to kill but it's killed before we kill it