### PR TITLE
MySql Concurrency Issues

### DIFF
--- a/src/SqlStreamStore.MySql/MySqlErrorMessages.cs
+++ b/src/SqlStreamStore.MySql/MySqlErrorMessages.cs
@@ -1,0 +1,8 @@
+namespace SqlStreamStore
+{
+    internal static class MySqlErrorMessages
+    {
+        public static string AppendFailedDeadlock(string streamId, int expectedVersion, int times) 
+            => $"Append failed due to deadlock persisting after retrying {times} times.Stream: {streamId}, Expected version: {expectedVersion}";
+    }
+}

--- a/src/SqlStreamStore.MySql/MySqlErrorMessages.cs
+++ b/src/SqlStreamStore.MySql/MySqlErrorMessages.cs
@@ -3,6 +3,6 @@ namespace SqlStreamStore
     internal static class MySqlErrorMessages
     {
         public static string AppendFailedDeadlock(string streamId, int expectedVersion, int times) 
-            => $"Append failed due to deadlock persisting after retrying {times} times.Stream: {streamId}, Expected version: {expectedVersion}";
+            => $"Append failed due to a deadlock persisting after retrying {times} times.Stream: {streamId}, Expected version: {expectedVersion}";
     }
 }

--- a/src/SqlStreamStore.MySql/MySqlExceptionExtensions.cs
+++ b/src/SqlStreamStore.MySql/MySqlExceptionExtensions.cs
@@ -6,5 +6,8 @@ namespace SqlStreamStore
     {
         public static bool IsWrongExpectedVersion(this MySqlException exception)
             => exception.Message.Equals("WrongExpectedVersion") || exception.SqlState == "23000";
+
+        public static bool IsDeadlock(this MySqlException exception)
+            => exception.Number == 1213;
     }
 }

--- a/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersion.sql
+++ b/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersion.sql
@@ -15,7 +15,8 @@ BEGIN
 
     SELECT streams.id_internal INTO _stream_id_internal
     FROM streams
-    WHERE streams.id = _stream_id;
+    WHERE streams.id = _stream_id
+    FOR UPDATE;
 
     IF (SELECT streams.version
         FROM streams

--- a/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersionAny.sql
+++ b/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersionAny.sql
@@ -19,7 +19,8 @@ BEGIN
 
     SELECT streams.id_internal INTO _stream_id_internal
     FROM streams
-    WHERE streams.id = _stream_id;
+    WHERE streams.id = _stream_id
+    FOR UPDATE;
 
     IF _stream_id_internal IS NULL THEN
         CALL get_stream_metadata(_metadata_stream_id, _max_age, _max_count);

--- a/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersionEmptyStream.sql
+++ b/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersionEmptyStream.sql
@@ -18,7 +18,8 @@ BEGIN
 
     SELECT streams.id_internal INTO _stream_id_internal
     FROM streams
-    WHERE streams.id = _stream_id;
+    WHERE streams.id = _stream_id
+    FOR UPDATE;
 
     IF _stream_id_internal IS NULL THEN
         CALL get_stream_metadata(_metadata_stream_id, _max_age, _max_count);

--- a/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersionNoStream.sql
+++ b/src/SqlStreamStore.MySql/MySqlScripts/AppendToStreamExpectedVersionNoStream.sql
@@ -18,7 +18,8 @@ BEGIN
 
     SELECT streams.id_internal INTO _stream_id_internal
     FROM streams
-    WHERE streams.id = _stream_id;
+    WHERE streams.id = _stream_id
+    FOR UPDATE;
 
     IF _stream_id_internal IS NULL THEN
         CALL get_stream_metadata(_metadata_stream_id, _max_age, _max_count);

--- a/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs
@@ -1,6 +1,7 @@
 namespace SqlStreamStore
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using MySql.Data.MySqlClient;
@@ -18,22 +19,38 @@ namespace SqlStreamStore
         {
             var streamIdInfo = new StreamIdInfo(streamId);
 
-            try
+            var retryableExceptions = new List<Exception>();
+            while(retryableExceptions.Count <= _settings.DeadlockRetryAttempts)
             {
-                return messages.Length == 0
-                    ? await CreateEmptyStream(streamIdInfo, expectedVersion, cancellationToken)
-                    : await AppendMessagesToStream(streamIdInfo, expectedVersion, messages, cancellationToken);
-            }
-            catch(MySqlException ex) when(ex.IsWrongExpectedVersion())
-            {
-                throw new WrongExpectedVersionException(
-                    ErrorMessages.AppendFailedWrongExpectedVersion(
+                try
+                {
+                    return messages.Length == 0
+                        ? await CreateEmptyStream(streamIdInfo, expectedVersion, cancellationToken)
+                        : await AppendMessagesToStream(streamIdInfo, expectedVersion, messages, cancellationToken);
+                }
+                catch(MySqlException ex) when(ex.IsDeadlock())
+                {
+                    retryableExceptions.Add(ex);
+                }
+                catch(MySqlException ex) when(ex.IsWrongExpectedVersion())
+                {
+                    throw new WrongExpectedVersionException(
+                        ErrorMessages.AppendFailedWrongExpectedVersion(
+                            streamIdInfo.MySqlStreamId.IdOriginal,
+                            expectedVersion),
                         streamIdInfo.MySqlStreamId.IdOriginal,
-                        expectedVersion),
+                        expectedVersion,
+                        ex);
+                }
+            }
+            throw new WrongExpectedVersionException(
+                MySqlErrorMessages.AppendFailedDeadlock(
                     streamIdInfo.MySqlStreamId.IdOriginal,
                     expectedVersion,
-                    ex);
-            }
+                    _settings.DeadlockRetryAttempts),
+                streamIdInfo.MySqlStreamId.IdOriginal,
+                expectedVersion,
+                retryableExceptions.Count == 1 ? retryableExceptions[0] : new AggregateException(retryableExceptions));
         }
 
         private async Task<AppendResult> AppendMessagesToStream(

--- a/src/SqlStreamStore.MySql/MySqlStreamStore.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStore.cs
@@ -14,7 +14,7 @@
 
     /// <inheritdoc />
     /// <summary>
-    ///     Represents a PostgreSQL stream store implementation.
+    ///     Represents a MySql stream store implementation.
     /// </summary>
     public partial class MySqlStreamStore : StreamStoreBase
     {

--- a/src/SqlStreamStore.MySql/MySqlStreamStoreSettings.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStoreSettings.cs
@@ -84,7 +84,7 @@ namespace SqlStreamStore
         public bool DisableDeletionTracking { get; set; }
 
         /// <summary>
-        ///     Indicates how long many times an operation should be retried
+        ///     Indicates how many times an operation should be retried
         ///     if a deadlock is detected. Defaults to 0.
         /// </summary>
         public int DeadlockRetryAttempts { get; set; }

--- a/src/SqlStreamStore.MySql/MySqlStreamStoreSettings.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStoreSettings.cs
@@ -10,6 +10,7 @@ namespace SqlStreamStore
     {
         private Func<string, MySqlConnection> _connectionFactory;
         private GetUtcNow _getUtcNow = SystemClock.GetUtcNow;
+        private int _appendDeadlockRetryAttempts = 0;
         private readonly MySqlConnectionStringBuilder _connectionStringBuilder;
 
         /// <summary>
@@ -84,9 +85,17 @@ namespace SqlStreamStore
         public bool DisableDeletionTracking { get; set; }
 
         /// <summary>
-        ///     Indicates how many times an operation should be retried
+        ///     Indicates how many times an append operation should be retried
         ///     if a deadlock is detected. Defaults to 0.
         /// </summary>
-        public int DeadlockRetryAttempts { get; set; }
+        public int AppendDeadlockRetryAttempts
+        {
+            get => _appendDeadlockRetryAttempts;
+            set
+            {
+                Ensure.That(value, nameof(value)).IsGte(0);
+                _appendDeadlockRetryAttempts = value;
+            }
+        }
     }
 }

--- a/src/SqlStreamStore.MySql/MySqlStreamStoreSettings.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStoreSettings.cs
@@ -82,5 +82,11 @@ namespace SqlStreamStore
         ///     message has been deleted. This can be modified at runtime.
         /// </summary>
         public bool DisableDeletionTracking { get; set; }
+
+        /// <summary>
+        ///     Indicates how long many times an operation should be retried
+        ///     if a deadlock is detected. Defaults to 0.
+        /// </summary>
+        public int DeadlockRetryAttempts { get; set; }
     }
 }

--- a/tests/SqlStreamStore.MySql.Tests/MySqlStreamStoreFixture.cs
+++ b/tests/SqlStreamStore.MySql.Tests/MySqlStreamStoreFixture.cs
@@ -28,7 +28,7 @@ namespace SqlStreamStore
             {
                 GetUtcNow = () => GetUtcNow(),
                 ScavengeAsynchronously = false,
-                DeadlockRetryAttempts = 25
+                AppendDeadlockRetryAttempts = 25
             };
         }
 

--- a/tests/SqlStreamStore.MySql.Tests/MySqlStreamStoreFixture.cs
+++ b/tests/SqlStreamStore.MySql.Tests/MySqlStreamStoreFixture.cs
@@ -27,7 +27,8 @@ namespace SqlStreamStore
             _settings = new MySqlStreamStoreSettings(ConnectionString)
             {
                 GetUtcNow = () => GetUtcNow(),
-                ScavengeAsynchronously = false
+                ScavengeAsynchronously = false,
+                DeadlockRetryAttempts = 25
             };
         }
 


### PR DESCRIPTION
Able to emulate the mysql concurrency issues, a deadlock and a uniqueness violation, which the other implementations seem to survive just fine.

## Deadlock

```
SqlStreamStore.MySqlStreamStoreAcceptanceTests.When_append_to_different_streams_concurrently_with_no_stream_expected_and_same_messages_then_should_then_should_have_expected_result

MySql.Data.MySqlClient.MySqlException : Deadlock found when trying to get lock; try restarting transaction
---- MySql.Data.MySqlClient.MySqlException : Deadlock found when trying to get lock; try restarting transaction
   at MySql.Data.MySqlClient.MySqlDataReader.ActivateResultSet(ResultSet resultSet) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 81
   at MySql.Data.MySqlClient.MySqlDataReader.ReadFirstResultSetAsync(IOBehavior ioBehavior) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 310
   at MySql.Data.MySqlClient.MySqlDataReader.CreateAsync(MySqlCommand command, CommandBehavior behavior, ResultSetProtocol resultSetProtocol, IOBehavior ioBehavior) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 295
   at MySqlConnector.Core.TextCommandExecutor.ExecuteReaderAsync(String commandText, MySqlParameterCollection parameterCollection, CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken) in C:\projects\mysqlconnector\src\MySqlConnector\Core\TextCommandExecutor.cs:line 37
   at MySqlConnector.Core.StoredProcedureCommandExecutor.ExecuteReaderAsync(String commandText, MySqlParameterCollection parameterCollection, CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken) in C:\projects\mysqlconnector\src\MySqlConnector\Core\StoredProcedureCommandExecutor.cs:line 79
   at MySql.Data.MySqlClient.MySqlCommand.ExecuteScalarAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlCommand.cs:line 296
   at SqlStreamStore.MySqlStreamStore.AppendToStreamExpectedVersionNoStream(StreamIdInfo streamId, NewStreamMessage message, MySqlTransaction transaction, CancellationToken cancellationToken) in /home/yves/Code/SQLStreamStore/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs:line 190
   at SqlStreamStore.MySqlStreamStore.AppendMessagesToStream(StreamIdInfo streamId, Int32 expectedVersion, NewStreamMessage[] messages, CancellationToken cancellationToken) in /home/yves/Code/SQLStreamStore/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs:line 58
   at SqlStreamStore.MySqlStreamStore.AppendToStreamInternal(String streamId, Int32 expectedVersion, NewStreamMessage[] messages, CancellationToken cancellationToken) in /home/yves/Code/SQLStreamStore/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs:line 23
   at SqlStreamStore.AcceptanceTests.When_append_to_different_streams_concurrently_with_no_stream_expected_and_same_messages_then_should_then_should_have_expected_result() in /home/yves/Code/SQLStreamStore/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.AppendStream.cs:line 747
--- End of stack trace from previous location where exception was thrown ---
----- Inner Stack Trace -----
   at MySqlConnector.Core.ServerSession.TryAsyncContinuation(Task`1 task) in C:\projects\mysqlconnector\src\MySqlConnector\Core\ServerSession.cs:line 1250
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
--- End of stack trace from previous location where exception was thrown ---
   at MySqlConnector.Core.ResultSet.ReadResultSetHeaderAsync(IOBehavior ioBehavior) in C:\projects\mysqlconnector\src\MySqlConnector\Core\ResultSet.cs:line 43
```

## Uniqueness

```
SqlStreamStore.MySqlStreamStoreAcceptanceTests.When_append_stream_concurrently_with_no_stream_expected_and_same_messages_then_should_then_should_have_expected_result

SqlStreamStore.Streams.WrongExpectedVersionException : Append failed due to WrongExpectedVersion.Stream: stream-1, Expected version: -3
---- MySql.Data.MySqlClient.MySqlException : Duplicate entry '0268031BC591AD2023A9540AB9658BD67CB296D8' for key 'uq_streams_id'
-------- MySql.Data.MySqlClient.MySqlException : Duplicate entry '0268031BC591AD2023A9540AB9658BD67CB296D8' for key 'uq_streams_id'
   at SqlStreamStore.MySqlStreamStore.AppendToStreamInternal(String streamId, Int32 expectedVersion, NewStreamMessage[] messages, CancellationToken cancellationToken) in /home/yves/Code/SQLStreamStore/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs:line 29
   at SqlStreamStore.AcceptanceTests.When_append_stream_concurrently_with_no_stream_expected_and_same_messages_then_should_then_should_have_expected_result() in /home/yves/Code/SQLStreamStore/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.AppendStream.cs:line 728
--- End of stack trace from previous location where exception was thrown ---
----- Inner Stack Trace -----
   at MySql.Data.MySqlClient.MySqlDataReader.ActivateResultSet(ResultSet resultSet) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 81
   at MySql.Data.MySqlClient.MySqlDataReader.ReadFirstResultSetAsync(IOBehavior ioBehavior) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 310
   at MySql.Data.MySqlClient.MySqlDataReader.CreateAsync(MySqlCommand command, CommandBehavior behavior, ResultSetProtocol resultSetProtocol, IOBehavior ioBehavior) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 295
   at MySqlConnector.Core.TextCommandExecutor.ExecuteReaderAsync(String commandText, MySqlParameterCollection parameterCollection, CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken) in C:\projects\mysqlconnector\src\MySqlConnector\Core\TextCommandExecutor.cs:line 37
   at MySqlConnector.Core.StoredProcedureCommandExecutor.ExecuteReaderAsync(String commandText, MySqlParameterCollection parameterCollection, CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken) in C:\projects\mysqlconnector\src\MySqlConnector\Core\StoredProcedureCommandExecutor.cs:line 79
   at MySql.Data.MySqlClient.MySqlCommand.ExecuteScalarAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlCommand.cs:line 296
   at SqlStreamStore.MySqlStreamStore.AppendToStreamExpectedVersionNoStream(StreamIdInfo streamId, NewStreamMessage message, MySqlTransaction transaction, CancellationToken cancellationToken) in /home/yves/Code/SQLStreamStore/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs:line 190
   at SqlStreamStore.MySqlStreamStore.AppendMessagesToStream(StreamIdInfo streamId, Int32 expectedVersion, NewStreamMessage[] messages, CancellationToken cancellationToken) in /home/yves/Code/SQLStreamStore/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs:line 58
   at SqlStreamStore.MySqlStreamStore.AppendToStreamInternal(String streamId, Int32 expectedVersion, NewStreamMessage[] messages, CancellationToken cancellationToken) in /home/yves/Code/SQLStreamStore/src/SqlStreamStore.MySql/MySqlStreamStore.Append.cs:line 23
----- Inner Stack Trace -----
   at MySqlConnector.Core.ServerSession.TryAsyncContinuation(Task`1 task) in C:\projects\mysqlconnector\src\MySqlConnector\Core\ServerSession.cs:line 1250
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
--- End of stack trace from previous location where exception was thrown ---
   at MySqlConnector.Core.ResultSet.ReadResultSetHeaderAsync(IOBehavior ioBehavior) in C:\projects\mysqlconnector\src\MySqlConnector\Core\ResultSet.cs:line 43
```