### PR TITLE
Fix InMemoryStreamstore reading a stream backwards with gaps

### DIFF
--- a/tests/SqlStreamStore.Tests/InMemory/InMemoryTests.cs
+++ b/tests/SqlStreamStore.Tests/InMemory/InMemoryTests.cs
@@ -1,0 +1,34 @@
+namespace SqlStreamStore.InMemory
+{
+    using System;
+    using System.Linq;
+    using Shouldly;
+    using SqlStreamStore.Streams;
+    using Xunit;
+
+    public class InMemoryTests
+    {
+        [Fact]
+        public async void When_reading_a_stream_backwards_with_gaps_and_providing_the_fromVersion_explicitly()
+        {
+            var streamStore = new InMemoryStreamStore();
+            var streamId = new StreamId("streamid");
+            var messageOne = new NewStreamMessage(Guid.NewGuid(), "type", "jsondata1");
+            var messageTwo = new NewStreamMessage(Guid.NewGuid(), "type", "jsondata2");
+            var messageThree = new NewStreamMessage(Guid.NewGuid(), "type", "jsondata3");
+
+            var ap1 = await streamStore.AppendToStream(streamId, ExpectedVersion.Any, messageOne);
+            var ap2 = await streamStore.AppendToStream(streamId, ExpectedVersion.Any, messageTwo);
+            var ap3 = await streamStore.AppendToStream(streamId, ExpectedVersion.Any, messageThree);
+
+            await streamStore.DeleteMessage(streamId, messageTwo.MessageId);
+
+            var page = await streamStore.ReadStreamBackwards(streamId, ap3.CurrentVersion, 10);
+            page.Messages.Length.ShouldBe(2);
+            var jsonDataOfMessageOne = await page.Messages.First().GetJsonData();
+            var jsonDataOfMessageThree = await page.Messages.Last().GetJsonData();
+            jsonDataOfMessageOne.ShouldBe("jsondata3");
+            jsonDataOfMessageThree.ShouldBe("jsondata1");
+        }
+    }
+}


### PR DESCRIPTION
This PR will fix an issue in the InMemoryStreamStore `ReadStreamBackwardsInternal` where it cannot find all messages anymore when there a gaps in the stream (caused by delete operations).

questions:
- Could this new approach cause any performance issues?
- Is this only a InMemoryStreamStore issue? Can this issue also occur in the other providers? (I haven't checked this)
- I'm not sure if the spec that I wrote is in the correct location (I didn't find any explicit inmemory specs yet)

