### PR TITLE
Fix: hanging builds by upgrading dotnet core docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100-alpine3.10 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.201-alpine3.11 AS build
 
 RUN apk add git
 


### PR DESCRIPTION
This PR updates the docker image used for building the solution and will fix the hanging builds.

Master is broken because of some failing tests 