### PR TITLE
Introduce command timeout as a mssql setting and apply to sqlcommands

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
@@ -141,6 +141,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionAny, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
@@ -252,6 +253,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionNoStream, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
@@ -364,6 +366,7 @@
 
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersion, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                 var eventsParam = CreateNewMessagesSqlParameter(sqlDataRecords);
@@ -487,6 +490,7 @@
         {
             using(var command = new SqlCommand(_scripts.GetStreamVersionOfMessageId, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("messageId", messageId);
 

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.Delete.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.Delete.cs
@@ -39,6 +39,7 @@ namespace SqlStreamStore
                     bool deleted;
                     using (var command = new SqlCommand(_scripts.DeleteStreamMessage, connection, transaction))
                     {
+                        command.CommandTimeout = _commandTimeout;
                         command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                         command.Parameters.AddWithValue("eventId", eventId);
                         var count  = await command
@@ -77,6 +78,7 @@ namespace SqlStreamStore
                 {
                     using(var command = new SqlCommand(_scripts.DeleteStreamExpectedVersion, connection, transaction))
                     {
+                        command.CommandTimeout = _commandTimeout;
                         command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                         command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                         try
@@ -145,6 +147,7 @@ namespace SqlStreamStore
             bool aStreamIsDeleted;
             using (var command = new SqlCommand(_scripts.DeleteStreamAnyVersion, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 var i = await command
                     .ExecuteScalarAsync(cancellationToken)

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadAll.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadAll.cs
@@ -29,6 +29,7 @@ namespace SqlStreamStore
                 var commandText = prefetch ? _scripts.ReadAllForwardWithData : _scripts.ReadAllForward;
                 using (var command = new SqlCommand(commandText, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.AddWithValue("position", position);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not
                     var reader = await command
@@ -126,6 +127,7 @@ namespace SqlStreamStore
                 var commandText = prefetch ? _scripts.ReadAllBackwardWithData : _scripts.ReadAllBackward;
                 using (var command = new SqlCommand(commandText, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.AddWithValue("position", position);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not
                     var reader = await command

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.ReadStream.cs
@@ -108,6 +108,7 @@
 
             using (var command = new SqlCommand(commandText, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("count", count + 1); //Read extra row to see if at end or not
                 command.Parameters.AddWithValue("streamVersion", streamVersion);
@@ -204,6 +205,7 @@
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
                 using(var command = new SqlCommand(_scripts.ReadMessageData, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamId });
                     command.Parameters.AddWithValue("streamVersion", streamVersion);
 

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
@@ -22,6 +22,7 @@
         private readonly Lazy<IStreamStoreNotifier> _streamStoreNotifier;
         private readonly Scripts _scripts;
         private readonly SqlMetaData[] _appendToStreamSqlMetadata;
+        private readonly int _commandTimeout;
         public const int FirstSchemaVersion = 1;
         public const int CurrentSchemaVersion = 2;
 
@@ -64,6 +65,7 @@
             }
 
             _appendToStreamSqlMetadata = sqlMetaData.ToArray();
+            _commandTimeout = settings.CommandTimeout;
         }
 
         /// <summary>
@@ -91,6 +93,8 @@
                         EXEC sp_executesql N'CREATE SCHEMA {_scripts.Schema}'
                         END", connection))
                     {
+                        command.CommandTimeout = _commandTimeout;
+
                         await command
                             .ExecuteNonQueryAsync(cancellationToken)
                             .NotOnCapturedContext();
@@ -99,6 +103,8 @@
 
                 using (var command = new SqlCommand(_scripts.CreateSchema, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
+
                     await command.ExecuteNonQueryAsync(cancellationToken)
                         .NotOnCapturedContext();
                 }
@@ -125,6 +131,8 @@
                         EXEC sp_executesql N'CREATE SCHEMA {_scripts.Schema}'
                         END", connection))
                     {
+                        command.CommandTimeout = _commandTimeout;
+
                         await command
                             .ExecuteNonQueryAsync(cancellationToken)
                             .NotOnCapturedContext();
@@ -133,6 +141,8 @@
 
                 using (var command = new SqlCommand(_scripts.CreateSchema_v1, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
+
                     await command.ExecuteNonQueryAsync(cancellationToken)
                         .NotOnCapturedContext();
                 }
@@ -155,6 +165,8 @@
 
                 using (var command = new SqlCommand(_scripts.GetSchemaVersion, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
+
                     var extendedProperties =  await command
                         .ExecuteReaderAsync(cancellationToken)
                         .NotOnCapturedContext();
@@ -190,6 +202,8 @@
 
                 using(var command = new SqlCommand(_scripts.DropAll, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
+
                     await command
                         .ExecuteNonQueryAsync(cancellationToken)
                         .NotOnCapturedContext();
@@ -210,6 +224,7 @@
                 using(var command = new SqlCommand(_scripts.GetStreamMessageCount, connection))
                 {
                     var streamIdInfo = new StreamIdInfo(streamId);
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
 
                     var result = await command
@@ -235,6 +250,7 @@
                 using (var command = new SqlCommand(_scripts.GetStreamMessageBeforeCreatedCount, connection))
                 {
                     var streamIdInfo = new StreamIdInfo(streamId);
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                     command.Parameters.AddWithValue("created", createdBefore);
 
@@ -257,6 +273,7 @@
 
                 using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     var result = await command
                         .ExecuteScalarAsync(cancellationToken)
                         .NotOnCapturedContext();

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreSettings.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreSettings.cs
@@ -13,6 +13,7 @@ namespace SqlStreamStore
     public class MsSqlStreamStoreSettings
     {
         private string _schema = "dbo";
+        private int _commandTimeout = 30;
 
         /// <summary>
         ///     Initialized a new instance of <see cref="MsSqlStreamStoreSettings"/>.
@@ -86,5 +87,18 @@ namespace SqlStreamStore
         ///     The default implementation simply passes the connection string into the <see cref="SqlConnection"/> constructor.
         /// </summary>
         public Func<string, SqlConnection> ConnectionFactory { get; set; } = connectionString => new SqlConnection(connectionString);
+
+        /// <summary>
+        ///     Controls the wait time to execute a command. Defaults to 30 seconds.
+        /// </summary>
+        public int CommandTimeout
+        {
+            get => _commandTimeout;
+            set
+            {
+                Ensure.That(value, nameof(CommandTimeout)).IsGte(0);
+                _commandTimeout = value;
+            }
+        }
     }
 }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.AppendStream.cs
@@ -151,6 +151,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionAny, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
@@ -257,6 +258,7 @@
         {
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersionNoStream, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("streamIdOriginal", sqlStreamId.IdOriginal);
 
@@ -363,6 +365,7 @@
 
             using(var command = new SqlCommand(_scripts.AppendStreamExpectedVersion, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                 var eventsParam = CreateNewMessagesSqlParameter(sqlDataRecords);
@@ -478,6 +481,7 @@
         {
             using(var command = new SqlCommand(_scripts.GetStreamVersionOfMessageId, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("messageId", messageId);
 

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.Delete.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.Delete.cs
@@ -38,6 +38,7 @@ namespace SqlStreamStore
                     bool deleted;
                     using (var command = new SqlCommand(_scripts.DeleteStreamMessage, connection, transaction))
                     {
+                        command.CommandTimeout = _commandTimeout;
                         command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                         command.Parameters.AddWithValue("eventId", eventId);
                         var count  = await command
@@ -76,6 +77,7 @@ namespace SqlStreamStore
                 {
                     using(var command = new SqlCommand(_scripts.DeleteStreamExpectedVersion, connection, transaction))
                     {
+                        command.CommandTimeout = _commandTimeout;
                         command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                         command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);
                         try
@@ -147,6 +149,7 @@ namespace SqlStreamStore
             bool aStreamIsDeleted;
             using (var command = new SqlCommand(_scripts.DeleteStreamAnyVersion, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 var i = await command
                     .ExecuteScalarAsync(cancellationToken)

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ListStreams.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ListStreams.cs
@@ -28,12 +28,15 @@ namespace SqlStreamStore
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
                 using(var transaction = connection.BeginTransaction())
                 using(var command = GetListStreamsCommand(pattern, maxCount, afterIdInternal, transaction))
-                using(var reader = await command.ExecuteReaderAsync(cancellationToken).NotOnCapturedContext())
                 {
-                    while(await reader.ReadAsync(cancellationToken).NotOnCapturedContext())
+                    command.CommandTimeout = _commandTimeout;
+                    using(var reader = await command.ExecuteReaderAsync(cancellationToken).NotOnCapturedContext())
                     {
-                        streamIds.Add(reader.GetString(0));
-                        afterIdInternal = reader.GetInt32(1);
+                        while(await reader.ReadAsync(cancellationToken).NotOnCapturedContext())
+                        {
+                            streamIds.Add(reader.GetString(0));
+                            afterIdInternal = reader.GetInt32(1);
+                        }
                     }
                 }
 

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadAll.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadAll.cs
@@ -29,6 +29,7 @@ namespace SqlStreamStore
                 var commandText = prefetch ? _scripts.ReadAllForwardWithData : _scripts.ReadAllForward;
                 using (var command = new SqlCommand(commandText, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.AddWithValue("position", position);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not
                     var reader = await command
@@ -123,6 +124,7 @@ namespace SqlStreamStore
                 var commandText = prefetch ? _scripts.ReadAllBackwardWithData : _scripts.ReadAllBackward;
                 using (var command = new SqlCommand(commandText, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.AddWithValue("position", position);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not
                     var reader = await command

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadStream.cs
@@ -102,6 +102,7 @@
 
             using(var command = new SqlCommand(commandText, connection, transaction))
             {
+                command.CommandTimeout = _commandTimeout;
                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = sqlStreamId.Id });
                 command.Parameters.AddWithValue("count", count + 1); //Read extra row to see if at end or not
                 command.Parameters.AddWithValue("streamVersion", streamVersion);
@@ -205,6 +206,7 @@
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
                 using (var command = new SqlCommand(_scripts.ReadMessageData, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamId });
                     command.Parameters.AddWithValue("streamVersion", streamVersion);
 

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.StreamMetadata.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.StreamMetadata.cs
@@ -88,6 +88,7 @@
 
                     using(var command = new SqlCommand(_scripts.SetStreamMetadata, connection, transaction))
                     {
+                        command.CommandTimeout = _commandTimeout;
                         command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
                         command.Parameters.AddWithValue("streamIdOriginal", streamIdInfo.SqlStreamId.IdOriginal);
                         command.Parameters.Add("maxAge", SqlDbType.Int);

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
@@ -24,6 +24,7 @@
         private readonly Scripts _scripts;
         private readonly SqlMetaData[] _appendToStreamSqlMetadata;
         private readonly MsSqlStreamStoreV3Settings _settings;
+        private readonly int _commandTimeout;
         public const int FirstSchemaVersion = 1;
         public const int CurrentSchemaVersion = 3;
 
@@ -66,6 +67,7 @@
             }
 
             _appendToStreamSqlMetadata = sqlMetaData.ToArray();
+            _commandTimeout = settings.CommandTimeout;
         }
 
         /// <summary>
@@ -95,6 +97,7 @@
                         EXEC sp_executesql N'CREATE SCHEMA {_scripts.Schema}'
                         END", connection))
                     {
+                        command.CommandTimeout = _commandTimeout;
                         await command
                             .ExecuteNonQueryAsync(cancellationToken)
                             .NotOnCapturedContext();
@@ -103,6 +106,7 @@
 
                 using (var command = new SqlCommand(_scripts.CreateSchema, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     await command
                         .ExecuteNonQueryAsync(cancellationToken)
                         .NotOnCapturedContext();
@@ -126,6 +130,7 @@
 
                 using (var command = new SqlCommand(_scripts.GetSchemaVersion, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     var extendedProperties =  await command
                         .ExecuteReaderAsync(cancellationToken)
                         .NotOnCapturedContext();
@@ -163,6 +168,7 @@
 
                 using(var command = new SqlCommand(_scripts.DropAll, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     await command
                         .ExecuteNonQueryAsync(cancellationToken)
                         .NotOnCapturedContext();
@@ -183,6 +189,7 @@
                 using(var command = new SqlCommand(_scripts.GetStreamMessageCount, connection))
                 {
                     var streamIdInfo = new StreamIdInfo(streamId);
+                    command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = streamIdInfo.SqlStreamId.Id });
 
                     var result = await command
@@ -235,6 +242,7 @@
 
                     using(var command = new SqlCommand(_scripts.Migration_v3, connection))
                     {
+                        command.CommandTimeout = _commandTimeout;
                         await command
                             .ExecuteNonQueryAsync(cancellationToken)
                             .NotOnCapturedContext();
@@ -280,6 +288,7 @@
 
                             using(var command = new SqlCommand(_scripts.SetStreamMetadata, connection))
                             {
+                                command.CommandTimeout = _commandTimeout;
                                 command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
                                 command.Parameters.AddWithValue("streamIdOriginal", "ignored");
                                 command.Parameters.Add("maxAge", SqlDbType.Int);
@@ -311,6 +320,7 @@
 
                 using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
                 {
+                    command.CommandTimeout = _commandTimeout;
                     var result = await command
                         .ExecuteScalarAsync(cancellationToken)
                         .NotOnCapturedContext();

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3Settings.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3Settings.cs
@@ -12,6 +12,7 @@ namespace SqlStreamStore
     public class MsSqlStreamStoreV3Settings
     {
         private string _schema = "dbo";
+        private int _commandTimeout = 30;
 
         /// <summary>
         ///     Initialized a new instance of <see cref="MsSqlStreamStoreV3Settings"/>.
@@ -76,5 +77,18 @@ namespace SqlStreamStore
         ///     message has been deleted. This can be modified at runtime.
         /// </summary>
         public bool DisableDeletionTracking { get; set; }
+
+        /// <summary>
+        ///     Controls the wait time to execute a command. Defaults to 30 seconds.
+        /// </summary>
+        public int CommandTimeout
+        {
+            get => _commandTimeout;
+            set
+            {
+                Ensure.That(value, nameof(CommandTimeout)).IsGte(0);
+                _commandTimeout = value;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR introduces `CommandTimeout` as a setting of the MsSql Stream Store implementation, allowing callers to control the command timeout of a `SqlCommand`.