### PR TITLE
Fix for default fetch depth of actions/checkout@v2 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: '100'
     - name: Generate build number
       uses: einaregilsson/build-number@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        fetch-depth: '100'
+        fetch-depth: '0'
     - name: Generate build number
       uses: einaregilsson/build-number@v2
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        fetch-depth: '100'
+        fetch-depth: '0'
     - name: Build and Test
       run: bash build.sh
       shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: '100'
     - name: Build and Test
       run: bash build.sh
       shell: bash


### PR DESCRIPTION
actions/checkout@v2 uses a fetch depth of 1 for performance optimizations. This will not work with minver see:
https://github.com/adamralph/minver#why-is-the-default-version-sometimes-used-in-github-actions-and-travis-ci-when-a-version-tag-exists-in-the-history

This PR sets to fetch depth to 100. This should be enough to find the latest tag in the history.

R