### PR TITLE
ReadStreamHeadPosition/Version

### DIFF
--- a/src/SqlStreamStore.Http/HttpClientSqlStreamStore.cs
+++ b/src/SqlStreamStore.Http/HttpClientSqlStreamStore.cs
@@ -70,6 +70,44 @@
             return headPosition;
         }
 
+        public async Task<long> ReadStreamHeadPosition(StreamId streamId, CancellationToken cancellationToken = default)
+        {
+            GuardAgainstDisposed();
+
+            var client = CreateClient();
+            var response = await client.Client.HeadAsync(LinkFormatter.ReadStreamBackwards(streamId, StreamVersion.End, 1, false), cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+
+            var resource = client.Current.First();
+
+            if(client.StatusCode == HttpStatusCode.NotFound)
+            {
+                return -1L;
+            }
+
+            return resource.Data<HalReadPage>().LastStreamPosition;
+        }
+
+        public async Task<int> ReadStreamHeadVersion(StreamId streamId, CancellationToken cancellationToken = default)
+        {
+            GuardAgainstDisposed();
+
+            var client = CreateClient();
+            var response = await client.Client.HeadAsync(LinkFormatter.ReadStreamBackwards(streamId, StreamVersion.End, 1, false), cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+
+            var resource = client.Current.First();
+
+            if(client.StatusCode == HttpStatusCode.NotFound)
+            {
+                return -1;
+            }
+
+            return resource.Data<HalReadPage>().LastStreamVersion;
+        }
+
         private static void ThrowOnError(IHalClient client)
         {
             switch(client.StatusCode ?? default)

--- a/src/SqlStreamStore.Http/HttpClientSqlStreamStore.cs
+++ b/src/SqlStreamStore.Http/HttpClientSqlStreamStore.cs
@@ -74,38 +74,14 @@
         {
             GuardAgainstDisposed();
 
-            var client = CreateClient();
-            var response = await client.Client.HeadAsync(LinkFormatter.ReadStreamBackwards(streamId, StreamVersion.End, 1, false), cancellationToken);
-
-            response.EnsureSuccessStatusCode();
-
-            var resource = client.Current.First();
-
-            if(client.StatusCode == HttpStatusCode.NotFound)
-            {
-                return -1L;
-            }
-
-            return resource.Data<HalReadPage>().LastStreamPosition;
+            return (await ReadStreamBackwards(streamId, StreamVersion.End, 1, false, cancellationToken)).LastStreamPosition;
         }
 
         public async Task<int> ReadStreamHeadVersion(StreamId streamId, CancellationToken cancellationToken = default)
         {
             GuardAgainstDisposed();
 
-            var client = CreateClient();
-            var response = await client.Client.HeadAsync(LinkFormatter.ReadStreamBackwards(streamId, StreamVersion.End, 1, false), cancellationToken);
-
-            response.EnsureSuccessStatusCode();
-
-            var resource = client.Current.First();
-
-            if(client.StatusCode == HttpStatusCode.NotFound)
-            {
-                return -1;
-            }
-
-            return resource.Data<HalReadPage>().LastStreamVersion;
+            return (await ReadStreamBackwards(streamId, StreamVersion.End, 1, false, cancellationToken)).LastStreamVersion;
         }
 
         private static void ThrowOnError(IHalClient client)

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
@@ -10,6 +10,7 @@
     using SqlStreamStore.Imports.Ensure.That;
     using SqlStreamStore.Infrastructure;
     using SqlStreamStore.ScriptsV2;
+    using SqlStreamStore.Streams;
     using SqlStreamStore.Subscriptions;
 
     /// <summary>
@@ -280,7 +281,7 @@
 
                     if(result == DBNull.Value)
                     {
-                        return -1L;
+                        return Position.End;
                     }
                     return (long) result;
                 }
@@ -295,7 +296,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                using(var command = new SqlCommand(_scripts.ReadStreamHeadPosition, connection))
                 {
                     command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
@@ -303,9 +304,9 @@
                         .ExecuteScalarAsync(cancellationToken)
                         .NotOnCapturedContext();
 
-                    if(result == DBNull.Value)
+                    if(result == null)
                     {
-                        return -1L;
+                        return Position.End;
                     }
                     return (long) result;
                 }
@@ -320,7 +321,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                using(var command = new SqlCommand(_scripts.ReadStreamHeadVersion, connection))
                 {
                     command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
@@ -328,9 +329,9 @@
                         .ExecuteScalarAsync(cancellationToken)
                         .NotOnCapturedContext();
 
-                    if(result == DBNull.Value)
+                    if(result == null)
                     {
-                        return -1;
+                        return StreamVersion.End;
                     }
                     return (int) result;
                 }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
@@ -280,9 +280,59 @@
 
                     if(result == DBNull.Value)
                     {
-                        return -1;
+                        return -1L;
                     }
                     return (long) result;
+                }
+            }
+        }
+
+        protected override async Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            GuardAgainstDisposed();
+
+            using(var connection = _createConnection())
+            {
+                await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
+
+                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                {
+                    command.CommandTimeout = _commandTimeout;
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
+                    var result = await command
+                        .ExecuteScalarAsync(cancellationToken)
+                        .NotOnCapturedContext();
+
+                    if(result == DBNull.Value)
+                    {
+                        return -1L;
+                    }
+                    return (long) result;
+                }
+            }
+        }
+
+        protected override async Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            GuardAgainstDisposed();
+
+            using(var connection = _createConnection())
+            {
+                await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
+
+                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                {
+                    command.CommandTimeout = _commandTimeout;
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
+                    var result = await command
+                        .ExecuteScalarAsync(cancellationToken)
+                        .NotOnCapturedContext();
+
+                    if(result == DBNull.Value)
+                    {
+                        return -1;
+                    }
+                    return (int) result;
                 }
             }
         }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
@@ -327,9 +327,59 @@
 
                     if(result == DBNull.Value)
                     {
-                        return -1;
+                        return -1L;
                     }
                     return (long) result;
+                }
+            }
+        }
+
+        protected override async Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            GuardAgainstDisposed();
+
+            using(var connection = _createConnection())
+            {
+                await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
+
+                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                {
+                    command.CommandTimeout = _commandTimeout;
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
+                    var result = await command
+                        .ExecuteScalarAsync(cancellationToken)
+                        .NotOnCapturedContext();
+
+                    if(result == DBNull.Value)
+                    {
+                        return -1L;
+                    }
+                    return (long) result;
+                }
+            }
+        }
+
+        protected override async Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            GuardAgainstDisposed();
+
+            using(var connection = _createConnection())
+            {
+                await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
+
+                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                {
+                    command.CommandTimeout = _commandTimeout;
+                    command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
+                    var result = await command
+                        .ExecuteScalarAsync(cancellationToken)
+                        .NotOnCapturedContext();
+
+                    if(result == DBNull.Value)
+                    {
+                        return -1;
+                    }
+                    return (int) result;
                 }
             }
         }

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.cs
@@ -11,6 +11,7 @@
     using SqlStreamStore.Infrastructure;
     using SqlStreamStore.Logging;
     using SqlStreamStore.ScriptsV3;
+    using SqlStreamStore.Streams;
     using SqlStreamStore.Subscriptions;
 
     /// <summary>
@@ -327,7 +328,7 @@
 
                     if(result == DBNull.Value)
                     {
-                        return -1L;
+                        return Position.End;
                     }
                     return (long) result;
                 }
@@ -342,7 +343,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                using(var command = new SqlCommand(_scripts.ReadStreamHeadPosition, connection))
                 {
                     command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
@@ -350,9 +351,9 @@
                         .ExecuteScalarAsync(cancellationToken)
                         .NotOnCapturedContext();
 
-                    if(result == DBNull.Value)
+                    if(result == null)
                     {
-                        return -1L;
+                        return Position.End;
                     }
                     return (long) result;
                 }
@@ -367,7 +368,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using(var command = new SqlCommand(_scripts.ReadHeadPosition, connection))
+                using(var command = new SqlCommand(_scripts.ReadStreamHeadVersion, connection))
                 {
                     command.CommandTimeout = _commandTimeout;
                     command.Parameters.Add(new SqlParameter("streamId", SqlDbType.Char, 42) { Value = new StreamIdInfo(streamId).SqlStreamId.Id });
@@ -375,9 +376,9 @@
                         .ExecuteScalarAsync(cancellationToken)
                         .NotOnCapturedContext();
 
-                    if(result == DBNull.Value)
+                    if(result == null)
                     {
-                        return -1;
+                        return StreamVersion.End;
                     }
                     return (int) result;
                 }

--- a/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamHeadPosition.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamHeadPosition.sql
@@ -1,0 +1,3 @@
+     SELECT dbo.Streams.Position
+       FROM dbo.Streams
+       WHERE dbo.Streams.Id = @streamId

--- a/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamHeadVersion.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV2/ReadStreamHeadVersion.sql
@@ -1,0 +1,3 @@
+     SELECT dbo.Streams.[Version]
+       FROM dbo.Streams
+       WHERE dbo.Streams.Id = @streamId

--- a/src/SqlStreamStore.MsSql/ScriptsV2/Scripts.cs
+++ b/src/SqlStreamStore.MsSql/ScriptsV2/Scripts.cs
@@ -44,6 +44,10 @@
 
         internal string ReadHeadPosition => GetScript(nameof(ReadHeadPosition));
 
+        internal string ReadStreamHeadPosition => GetScript(nameof(ReadStreamHeadPosition));
+
+        internal string ReadStreamHeadVersion => GetScript(nameof(ReadStreamHeadVersion));
+
         internal string ReadAllForward => GetScript(nameof(ReadAllForward));
 
         internal string ReadAllForwardWithData => GetScript(nameof(ReadAllForwardWithData));

--- a/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamHeadPosition.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamHeadPosition.sql
@@ -1,0 +1,3 @@
+     SELECT dbo.Streams.Position
+       FROM dbo.Streams
+       WHERE dbo.Streams.Id = @streamId

--- a/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamHeadVersion.sql
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/ReadStreamHeadVersion.sql
@@ -1,0 +1,3 @@
+     SELECT dbo.Streams.[Version]
+       FROM dbo.Streams
+       WHERE dbo.Streams.Id = @streamId

--- a/src/SqlStreamStore.MsSql/ScriptsV3/Scripts.cs
+++ b/src/SqlStreamStore.MsSql/ScriptsV3/Scripts.cs
@@ -40,6 +40,10 @@
 
         internal string ReadHeadPosition => GetScript(nameof(ReadHeadPosition));
 
+        internal string ReadStreamHeadPosition => GetScript(nameof(ReadStreamHeadPosition));
+
+        internal string ReadStreamHeadVersion => GetScript(nameof(ReadStreamHeadVersion));
+
         internal string ReadAllForward => GetScript(nameof(ReadAllForward));
 
         internal string ReadAllForwardWithData => GetScript(nameof(ReadAllForwardWithData));

--- a/src/SqlStreamStore.MySql/MySqlScripts/ReadStreamHeadPosition.sql
+++ b/src/SqlStreamStore.MySql/MySqlScripts/ReadStreamHeadPosition.sql
@@ -1,0 +1,9 @@
+DROP PROCEDURE IF EXISTS read_stream_head_position;
+
+CREATE PROCEDURE read_stream_head_position(_stream_id CHAR(42))
+
+BEGIN
+  SELECT streams.position
+  FROM streams
+  WHERE streams.id = _stream_id;
+END;

--- a/src/SqlStreamStore.MySql/MySqlScripts/ReadStreamHeadVersion.sql
+++ b/src/SqlStreamStore.MySql/MySqlScripts/ReadStreamHeadVersion.sql
@@ -1,0 +1,9 @@
+DROP PROCEDURE IF EXISTS read_stream_head_version;
+
+CREATE PROCEDURE read_stream_head_version(_stream_id CHAR(42))
+
+BEGIN
+  SELECT streams.version
+  FROM streams
+  WHERE streams.id = _stream_id;
+END;

--- a/src/SqlStreamStore.MySql/MySqlScripts/Schema.cs
+++ b/src/SqlStreamStore.MySql/MySqlScripts/Schema.cs
@@ -21,6 +21,8 @@
         public string Read => "`read`";
         public string ReadAll => "read_all";
         public string ReadAllHeadPosition => "read_head_position";
+        public string ReadStreamHeadPosition => "read_stream_head_position";
+        public string ReadStreamHeadVersion => "read_stream_head_version";
         public string ReadJsonData => "read_json_data";
         public string ReadProperties => "read_properties";
 

--- a/src/SqlStreamStore.MySql/MySqlScripts/Scripts.cs
+++ b/src/SqlStreamStore.MySql/MySqlScripts/Scripts.cs
@@ -45,6 +45,10 @@
 
         private string ReadHeadPosition => GetScript(nameof(ReadHeadPosition));
 
+        private string ReadStreamHeadPosition => GetScript(nameof(ReadStreamHeadPosition));
+
+        private string ReadStreamHeadVersion => GetScript(nameof(ReadStreamHeadVersion));
+
         private string ReadProperties => GetScript(nameof(ReadProperties));
 
         private string ReadStreamVersionOfMessageId => GetScript(nameof(ReadStreamVersionOfMessageId));
@@ -72,6 +76,8 @@
             ReadAll,
             ReadJsonData,
             ReadHeadPosition,
+            ReadStreamHeadPosition,
+            ReadStreamHeadVersion,
             ReadProperties,
             ReadStreamVersionOfMessageId,
             Scavenge,

--- a/src/SqlStreamStore.MySql/MySqlStreamStore.Read.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStore.Read.cs
@@ -278,7 +278,7 @@ namespace SqlStreamStore
                 {
                     var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
 
-                    return result == DBNull.Value
+                    return result == null
                         ? Position.End
                         : ConvertPosition.FromMySqlToStreamStore((long) result);
                 }
@@ -299,8 +299,8 @@ namespace SqlStreamStore
                 {
                     var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
 
-                    return result == DBNull.Value
-                        ? -1
+                    return result == null
+                        ? StreamVersion.End
                         : (int) result;
                 }
             }

--- a/src/SqlStreamStore.MySql/MySqlStreamStore.Read.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStore.Read.cs
@@ -267,5 +267,47 @@ namespace SqlStreamStore
                 throw new ObjectDisposedException(disposedException.Message, exception);
             }
         }
+
+        protected override async Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using(var connection = await OpenConnection(cancellationToken))
+                using(var transaction = connection.BeginTransaction())
+                using(var command = BuildStoredProcedureCall(_schema.ReadStreamHeadPosition, transaction, Parameters.StreamId(new MySqlStreamId(streamId))))
+                {
+                    var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
+
+                    return result == DBNull.Value
+                        ? Position.End
+                        : ConvertPosition.FromMySqlToStreamStore((long) result);
+                }
+            }
+            catch(MySqlException exception) when(exception.InnerException is ObjectDisposedException disposedException)
+            {
+                throw new ObjectDisposedException(disposedException.Message, exception);
+            }
+        }
+
+        protected override async Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using(var connection = await OpenConnection(cancellationToken))
+                using(var transaction = connection.BeginTransaction())
+                using(var command = BuildStoredProcedureCall(_schema.ReadStreamHeadVersion, transaction, Parameters.StreamId(new MySqlStreamId(streamId))))
+                {
+                    var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
+
+                    return result == DBNull.Value
+                        ? -1
+                        : (int) result;
+                }
+            }
+            catch(MySqlException exception) when(exception.InnerException is ObjectDisposedException disposedException)
+            {
+                throw new ObjectDisposedException(disposedException.Message, exception);
+            }
+        }
     }
 }

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadPosition.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadPosition.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION __schema__.read_stream_head_position(
+  _stream_id      CHAR(42),
+)
+  RETURNS BIGINT
+AS $F$
+BEGIN
+  RETURN (SELECT (__schema__.streams.position) FROM __schema__.streams WHERE __schema__.streams.id = _stream_id);
+END;
+$F$
+LANGUAGE 'plpgsql';

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadPosition.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadPosition.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION __schema__.read_stream_head_position(
-  _stream_id      CHAR(42),
+  _stream_id      CHAR(42)
 )
   RETURNS BIGINT
 AS $F$

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadVersion.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadVersion.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION __schema__.read_stream_head_version(
+  _stream_id      CHAR(42),
+)
+  RETURNS INT
+AS $F$
+BEGIN
+  RETURN (SELECT (__schema__.streams.version) FROM __schema__.streams WHERE __schema__.streams.id = _stream_id);
+END;
+$F$
+LANGUAGE 'plpgsql';

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadVersion.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/ReadStreamHeadVersion.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION __schema__.read_stream_head_version(
-  _stream_id      CHAR(42),
+  _stream_id      CHAR(42)
 )
   RETURNS INT
 AS $F$

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/Schema.cs
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/Schema.cs
@@ -22,6 +22,8 @@
         public string Read => $"{_schema}.read";
         public string ReadAll => $"{_schema}.read_all";
         public string ReadAllHeadPosition => $"{_schema}.read_head_position";
+        public string ReadStreamHeadPosition => $"{_schema}.read_stream_head_position";
+        public string ReadStreamHeadVersion => $"{_schema}.read_stream_head_version";
         public string ReadJsonData => $"{_schema}.read_json_data";
         public string ReadSchemaVersion => $"{_schema}.read_schema_version";
         public string ReadStreamMessageBeforeCreatedCount => $"{_schema}.read_stream_message_before_created_count";

--- a/src/SqlStreamStore.Postgres/PgSqlScripts/Scripts.cs
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/Scripts.cs
@@ -43,6 +43,10 @@
 
         private string ReadHeadPosition => GetScript(nameof(ReadHeadPosition));
 
+        private string ReadStreamHeadPosition => GetScript(nameof(ReadStreamHeadPosition));
+
+        private string ReadStreamHeadVersion => GetScript(nameof(ReadStreamHeadVersion));
+
         private string ReadSchemaVersion => GetScript(nameof(ReadSchemaVersion));
 
         private string ReadStreamVersionOfMessageId => GetScript(nameof(ReadStreamVersionOfMessageId));
@@ -66,6 +70,8 @@
             ReadAll,
             ReadJsonData,
             ReadHeadPosition,
+            ReadStreamHeadPosition,
+            ReadStreamHeadVersion,
             ReadSchemaVersion,
             ReadStreamVersionOfMessageId,
             Scavenge,

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.Read.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.Read.cs
@@ -251,5 +251,29 @@
                 return result == DBNull.Value ? Position.End : (long) result;
             }
         }
+
+        protected override async Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            using(var connection = await OpenConnection(cancellationToken))
+            using(var transaction = connection.BeginTransaction())
+            using(var command = BuildFunctionCommand(_schema.ReadAllHeadPosition, transaction, Parameters.StreamId(new PostgresqlStreamId(streamId))))
+            {
+                var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
+
+                return result == DBNull.Value ? Position.End : (long) result;
+            }
+        }
+
+        protected override async Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            using(var connection = await OpenConnection(cancellationToken))
+            using(var transaction = connection.BeginTransaction())
+            using(var command = BuildFunctionCommand(_schema.ReadAllHeadPosition, transaction, Parameters.StreamId(new PostgresqlStreamId(streamId))))
+            {
+                var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
+
+                return result == DBNull.Value ? -1 : (int) result;
+            }
+        }
     }
 }

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.Read.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.Read.cs
@@ -256,7 +256,7 @@
         {
             using(var connection = await OpenConnection(cancellationToken))
             using(var transaction = connection.BeginTransaction())
-            using(var command = BuildFunctionCommand(_schema.ReadAllHeadPosition, transaction, Parameters.StreamId(new PostgresqlStreamId(streamId))))
+            using(var command = BuildFunctionCommand(_schema.ReadStreamHeadPosition, transaction, Parameters.StreamId(new PostgresqlStreamId(streamId))))
             {
                 var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
 
@@ -268,11 +268,11 @@
         {
             using(var connection = await OpenConnection(cancellationToken))
             using(var transaction = connection.BeginTransaction())
-            using(var command = BuildFunctionCommand(_schema.ReadAllHeadPosition, transaction, Parameters.StreamId(new PostgresqlStreamId(streamId))))
+            using(var command = BuildFunctionCommand(_schema.ReadStreamHeadVersion, transaction, Parameters.StreamId(new PostgresqlStreamId(streamId))))
             {
                 var result = await command.ExecuteScalarAsync(cancellationToken).NotOnCapturedContext();
 
-                return result == DBNull.Value ? -1 : (int) result;
+                return result == DBNull.Value ? StreamVersion.End : (int) result;
             }
         }
     }

--- a/src/SqlStreamStore.Sqlite/SqliteCommandExtensions.StreamOperations.cs
+++ b/src/SqlStreamStore.Sqlite/SqliteCommandExtensions.StreamOperations.cs
@@ -40,6 +40,32 @@ namespace SqlStreamStore
             return Task.CompletedTask;
         }
 
+        public Task<long?> StreamHeadPosition()
+        {
+            using(var command = CreateCommand())
+            {
+                command.CommandText = @"SELECT streams.position
+                                    FROM streams
+                                    WHERE streams.id_original = @streamId;";
+                command.Parameters.Clear();
+                command.Parameters.AddWithValue("@streamId", _streamId);
+                return Task.FromResult(command.ExecuteScalar<long?>());
+            }
+        }
+
+        public Task<int?> StreamHeadVersion()
+        {
+            using(var command = CreateCommand())
+            {
+                command.CommandText = @"SELECT streams.version
+                                    FROM streams
+                                    WHERE streams.id_original = @streamId;";
+                command.Parameters.Clear();
+                command.Parameters.AddWithValue("@streamId", _streamId);
+                return Task.FromResult(command.ExecuteScalar<int?>());
+            }
+        }
+
         public Task<long?> AllStreamPosition(ReadDirection direction, long? version)
         {
             using(var command = CreateCommand())

--- a/src/SqlStreamStore.Sqlite/SqliteStreamStore.cs
+++ b/src/SqlStreamStore.Sqlite/SqliteStreamStore.cs
@@ -84,6 +84,33 @@ namespace SqlStreamStore
             }
         }
 
+        protected override async Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            GuardAgainstDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using(var connection = OpenConnection())
+            {
+                return (await connection
+                    .Streams(streamId)
+                    .StreamHeadPosition() ?? Position.End);
+            }
+        }
+
+        protected override async Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken)
+        {
+            GuardAgainstDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using(var connection = OpenConnection())
+            {
+                return (await connection
+                    .Streams(streamId)
+                    .StreamHeadVersion() ?? StreamVersion.End);
+            }
+        }
+
+
         internal void CreateSchemaIfNotExists()
         {
             using(var connection = OpenConnection(false))

--- a/src/SqlStreamStore/IReadonlyStreamStore.cs
+++ b/src/SqlStreamStore/IReadonlyStreamStore.cs
@@ -204,15 +204,43 @@
             string name = null);
 
         /// <summary>
-        ///     Reads the head position (the postion of the very latest message).
+        ///     Reads the head position (the position of the very latest message).
         /// </summary>
         /// <param name="cancellationToken">
         ///     The cancellation instruction.
         /// </param>
         /// <returns>
-        ///     The head positon.
+        ///     The head position.
         /// </returns>
         Task<long> ReadHeadPosition(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Reads the head position (the position of the very latest message) of a particular stream.
+        /// </summary>
+        /// <param name="streamId">
+        ///     The stream to read the head position of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     The cancellation instruction.
+        /// </param>
+        /// <returns>
+        ///     The head position of the stream, or <c>-1</c> if no such stream or an empty stream.
+        /// </returns>
+        Task<long> ReadStreamHeadPosition(StreamId streamId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Reads the head version (the version of the very latest message) of a particular stream.
+        /// </summary>
+        /// <param name="streamId">
+        ///     The stream to read the head version of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     The cancellation instruction.
+        /// </param>
+        /// <returns>
+        ///     The head version of the stream, or <c>-1</c> if no such stream or an empty stream.
+        /// </returns>
+        Task<int> ReadStreamHeadVersion(StreamId streamId, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Gets the stream metadata.

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -697,6 +697,24 @@ namespace SqlStreamStore
             return message == null ? Task.FromResult(-1L) : Task.FromResult(message.Position);
         }
 
+        protected override Task<long> ReadStreamHeadPositionInternal(StreamId streamId, CancellationToken cancellationToken)
+        {
+            using(_lock.UseReadLock())
+            {
+                InMemoryStream stream;
+                return !_streams.TryGetValue(streamId, out stream) ? Task.FromResult(-1L) : Task.FromResult(Convert.ToInt64(stream.CurrentPosition));
+            }
+        }
+
+        protected override Task<int> ReadStreamHeadVersionInternal(StreamId streamId, CancellationToken cancellationToken)
+        {
+            using(_lock.UseReadLock())
+            {
+                InMemoryStream stream;
+                return !_streams.TryGetValue(streamId, out stream) ? Task.FromResult(-1) : Task.FromResult(stream.CurrentVersion);
+            }
+        }
+
         protected override IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
             AllStreamMessageReceived streamMessageReceived,

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -697,21 +697,19 @@ namespace SqlStreamStore
             return message == null ? Task.FromResult(-1L) : Task.FromResult(message.Position);
         }
 
-        protected override Task<long> ReadStreamHeadPositionInternal(StreamId streamId, CancellationToken cancellationToken)
+        protected override Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken)
         {
             using(_lock.UseReadLock())
             {
-                InMemoryStream stream;
-                return !_streams.TryGetValue(streamId, out stream) ? Task.FromResult(-1L) : Task.FromResult(Convert.ToInt64(stream.CurrentPosition));
+                return !_streams.TryGetValue(streamId, out InMemoryStream stream) ? Task.FromResult(-1L) : Task.FromResult(Convert.ToInt64(stream.CurrentPosition));
             }
         }
 
-        protected override Task<int> ReadStreamHeadVersionInternal(StreamId streamId, CancellationToken cancellationToken)
+        protected override Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken)
         {
             using(_lock.UseReadLock())
             {
-                InMemoryStream stream;
-                return !_streams.TryGetValue(streamId, out stream) ? Task.FromResult(-1) : Task.FromResult(stream.CurrentVersion);
+                return !_streams.TryGetValue(streamId, out InMemoryStream stream) ? Task.FromResult(-1) : Task.FromResult(stream.CurrentVersion);
             }
         }
 

--- a/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
@@ -316,8 +316,8 @@ namespace SqlStreamStore.Infrastructure
             ReadNextStreamPage readNext, CancellationToken cancellationToken);
 
         protected abstract Task<long> ReadHeadPositionInternal(CancellationToken cancellationToken);
-        protected abstract Task<long> ReadStreamHeadPositionInternal(StreamId streamId, CancellationToken cancellationToken);
-        protected abstract Task<int> ReadStreamHeadVersionInternal(StreamId streamId, CancellationToken cancellationToken);
+        protected abstract Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken);
+        protected abstract Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken);
 
         protected abstract IStreamSubscription SubscribeToStreamInternal(
             string streamId,

--- a/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
@@ -231,6 +231,24 @@ namespace SqlStreamStore.Infrastructure
             return ReadHeadPositionInternal(cancellationToken);
         }
 
+        public Task<long> ReadStreamHeadPosition(StreamId streamId, CancellationToken cancellationToken = default)
+        {
+            if (streamId == null) throw new ArgumentNullException(nameof(streamId));
+
+            GuardAgainstDisposed();
+
+            return ReadStreamHeadPositionInternal(streamId, cancellationToken);
+        }
+
+        public Task<int> ReadStreamHeadVersion(StreamId streamId, CancellationToken cancellationToken = default)
+        {
+            if (streamId == null) throw new ArgumentNullException(nameof(streamId));
+
+            GuardAgainstDisposed();
+
+            return ReadStreamHeadVersionInternal(streamId, cancellationToken);
+        }
+
         public Task<ListStreamsPage> ListStreams(
             int maxCount = 100,
             string continuationToken = default,
@@ -298,6 +316,8 @@ namespace SqlStreamStore.Infrastructure
             ReadNextStreamPage readNext, CancellationToken cancellationToken);
 
         protected abstract Task<long> ReadHeadPositionInternal(CancellationToken cancellationToken);
+        protected abstract Task<long> ReadStreamHeadPositionInternal(StreamId streamId, CancellationToken cancellationToken);
+        protected abstract Task<int> ReadStreamHeadVersionInternal(StreamId streamId, CancellationToken cancellationToken);
 
         protected abstract IStreamSubscription SubscribeToStreamInternal(
             string streamId,

--- a/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadHeadCheckpoint.cs
+++ b/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadHeadCheckpoint.cs
@@ -16,6 +16,16 @@
         }
 
         [Fact]
+        public async Task Given_store_with_empty_stream_when_get_head_position_Then_should_be_minus_one()
+        {
+            await Store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages());
+            
+            var head = await Store.ReadHeadPosition();
+
+            head.ShouldBe(-1);
+        }
+
+        [Fact]
         public async Task Given_store_with_messages_then_can_get_head_position()
         {
             await Store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));

--- a/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadHeadCheckpoint.cs
+++ b/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadHeadCheckpoint.cs
@@ -24,5 +24,65 @@
 
             head.ShouldBe(2);
         }
+
+        [Fact]
+        public async Task Given_no_stream_when_get_head_position_then_returns_expected_result()
+        {
+            await Store.AppendToStream("other-stream", ExpectedVersion.NoStream, CreateNewStreamMessages(1));
+
+            var head = await Store.ReadStreamHeadPosition("this-stream");
+
+            head.ShouldBe(-1);
+        }
+
+        [Fact]
+        public async Task Given_no_stream_when_get_head_version_then_returns_expected_result()
+        {
+            await Store.AppendToStream("other-stream", ExpectedVersion.NoStream, CreateNewStreamMessages(1));
+
+            var head = await Store.ReadStreamHeadVersion("this-stream");
+
+            head.ShouldBe(-1);
+        }
+
+        [Fact]
+        public async Task Given_empty_stream_when_get_head_position_then_returns_expected_result()
+        {
+            await Store.AppendToStream("this-stream", ExpectedVersion.NoStream, CreateNewStreamMessages());
+
+            var head = await Store.ReadStreamHeadPosition("this-stream");
+
+            head.ShouldBe(-1);
+        }
+
+        [Fact]
+        public async Task Given_empty_stream_when_get_head_version_then_returns_expected_result()
+        {
+            await Store.AppendToStream("this-stream", ExpectedVersion.NoStream, CreateNewStreamMessages());
+
+            var head = await Store.ReadStreamHeadVersion("this-stream");
+
+            head.ShouldBe(-1);
+        }
+
+        [Fact]
+        public async Task Given_filled_stream_when_get_head_position_then_returns_expected_result()
+        {
+            await Store.AppendToStream("this-stream", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+
+            var head = await Store.ReadStreamHeadPosition("this-stream");
+
+            head.ShouldBe(2L);
+        }
+
+        [Fact]
+        public async Task Given_filled_stream_when_get_head_version_then_returns_expected_result()
+        {
+            await Store.AppendToStream("this-stream", ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+
+            var head = await Store.ReadStreamHeadVersion("this-stream");
+
+            head.ShouldBe(2);
+        }
     }
 }


### PR DESCRIPTION
This PR introduces two new methods on `IReadonlyStreamStore` (non-breaking change):

- `ReadStreamHeadPosition`: reads the head position of a stream, i.e. the position of its last message
- `ReadStreamHeadVersion`: reads the head version of a stream, i.e. the version of its last message

The test suite was extended with additional acceptance tests to cover the behavior of these new operations. This is the basis for a follow-up PR (in that it will follow a similar pattern) which will introduce support for reading the stream head message as well as the all stream head message.