### PR TITLE
Read(Stream)HeadMessage

### DIFF
--- a/src/SqlStreamStore/IReadonlyStreamStore.cs
+++ b/src/SqlStreamStore/IReadonlyStreamStore.cs
@@ -210,9 +210,19 @@
         ///     The cancellation instruction.
         /// </param>
         /// <returns>
-        ///     The head position.
+        ///     The head position, or <c>-1</c> if there is none.
         /// </returns>
         Task<long> ReadHeadPosition(CancellationToken cancellationToken = default);
+        /// <summary>
+        ///     Reads the head message (the very latest message).
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     The cancellation instruction.
+        /// </param>
+        /// <returns>
+        ///     The head message, or <c>null</c> if there is no head message.
+        /// </returns>
+        Task<StreamMessage?> ReadHeadMessage(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Reads the head position (the position of the very latest message) of a particular stream.
@@ -241,6 +251,20 @@
         ///     The head version of the stream, or <c>-1</c> if no such stream or an empty stream.
         /// </returns>
         Task<int> ReadStreamHeadVersion(StreamId streamId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Reads the head message (the very latest message) of a particular stream.
+        /// </summary>
+        /// <param name="streamId">
+        ///     The stream to read the head message of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     The cancellation instruction.
+        /// </param>
+        /// <returns>
+        ///     The head message of the stream, or <c>null</c> if no such stream or an empty stream.
+        /// </returns>
+        Task<StreamMessage?> ReadStreamHeadMessage(StreamId streamId, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Gets the stream metadata.

--- a/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
@@ -240,6 +240,22 @@ namespace SqlStreamStore.Infrastructure
             return ReadStreamHeadPositionInternal(streamId, cancellationToken);
         }
 
+        public Task<StreamMessage?> ReadHeadMessage(CancellationToken cancellationToken = default)
+        {
+            GuardAgainstDisposed();
+
+            return ReadHeadMessageInternal(cancellationToken);
+        }
+
+        public Task<StreamMessage?> ReadStreamHeadMessage(StreamId streamId, CancellationToken cancellationToken = default)
+        {
+            if (streamId == null) throw new ArgumentNullException(nameof(streamId));
+
+            GuardAgainstDisposed();
+
+            return ReadStreamHeadMessageInternal(streamId, cancellationToken);
+        }
+
         public Task<int> ReadStreamHeadVersion(StreamId streamId, CancellationToken cancellationToken = default)
         {
             if (streamId == null) throw new ArgumentNullException(nameof(streamId));
@@ -318,6 +334,8 @@ namespace SqlStreamStore.Infrastructure
         protected abstract Task<long> ReadHeadPositionInternal(CancellationToken cancellationToken);
         protected abstract Task<long> ReadStreamHeadPositionInternal(string streamId, CancellationToken cancellationToken);
         protected abstract Task<int> ReadStreamHeadVersionInternal(string streamId, CancellationToken cancellationToken);
+        protected abstract Task<StreamMessage?> ReadHeadMessageInternal(CancellationToken cancellationToken);
+        protected abstract Task<StreamMessage?> ReadStreamHeadMessageInternal(string streamId, CancellationToken cancellationToken);
 
         protected abstract IStreamSubscription SubscribeToStreamInternal(
             string streamId,

--- a/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadHeadCheckpoint.cs
+++ b/tests/SqlStreamStore.AcceptanceTests/AcceptanceTests.ReadHeadCheckpoint.cs
@@ -94,5 +94,65 @@
 
             head.ShouldBe(2);
         }
+
+        [Fact]
+        public async Task Given_empty_store_when_get_head_message_Then_should_be_minus_one()
+        {
+            var head = await Store.ReadHeadMessage();
+
+            head.ShouldBe(default);
+        }
+
+        [Fact]
+        public async Task Given_store_with_empty_stream_when_get_head_message_Then_should_be_minus_one()
+        {
+            await Store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages());
+            
+            var head = await Store.ReadHeadMessage();
+
+            head.ShouldBe(default);
+        }
+
+        [Fact]
+        public async Task Given_store_with_messages_then_can_get_head_message()
+        {
+            var messages = CreateNewStreamMessages(1, 2, 3);
+            await Store.AppendToStream("stream-1", ExpectedVersion.NoStream, messages);
+
+            var head = await Store.ReadHeadMessage();
+
+            head.ShouldBe(messages[3]);
+        }
+
+        [Fact]
+        public async Task Given_no_stream_when_get_stream_head_message_then_returns_expected_result()
+        {
+            await Store.AppendToStream("other-stream", ExpectedVersion.NoStream, CreateNewStreamMessages(1));
+
+            var head = await Store.ReadStreamHeadMessage("this-stream");
+
+            head.ShouldBe(default);
+        }
+
+        [Fact]
+        public async Task Given_empty_stream_when_get_stream_head_message_then_returns_expected_result()
+        {
+            await Store.AppendToStream("this-stream", ExpectedVersion.NoStream, CreateNewStreamMessages());
+
+            var head = await Store.ReadStreamHeadMessage("this-stream");
+
+            head.ShouldBe(default);
+        }
+
+        [Fact]
+        public async Task Given_filled_stream_when_get_stream_head_message_then_returns_expected_result()
+        {
+            var messages = CreateNewStreamMessages(1, 2, 3);
+            await Store.AppendToStream("this-stream", ExpectedVersion.NoStream, messages);
+
+            var head = await Store.ReadStreamHeadMessage("this-stream");
+
+            head.ShouldBe(messages[3]);
+        }
     }
 }


### PR DESCRIPTION
This PR introduces two new methods on IReadonlyStreamStore (non-breaking change):

- ReadHeadMessage: reads the head message of all streams, i.e. the latest message
- ReadStreamHeadMessage: reads the head message of a stream, i.e. the lastest message

The test suite was extended with additional acceptance tests to cover the behavior of these new operations. This is the follow-up PR to #391.