### PR TITLE
remove build number from version

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,8 +10,6 @@
     <LangVersion>7.3</LangVersion>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerMinimumMajorMinor>1.2</MinVerMinimumMajorMinor>
-    <BUILD_NUMBER Condition="'$(BUILD_NUMBER)' == ''">0</BUILD_NUMBER>
-    <MinVerBuildMetadata>build.$(BUILD_NUMBER)</MinVerBuildMetadata>
     <DebugType>full</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>


### PR DESCRIPTION
I noticed this:

![image](https://user-images.githubusercontent.com/677704/86577628-7185ea00-bf72-11ea-897a-61b2a4274594.png)

The GitHub Actions workflow is not setting `BUILD_NUMBER` so it's always the default value of `0`. Thing is, GitHub Actions doesn't have build numbers. For that reason, I've stopped putting the build number into the versions of all my products. It never really added much value any way.