### PR TITLE
Mysql ReadAllForward improvements

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadAll.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStoreV3.ReadAll.cs
@@ -36,7 +36,6 @@ namespace SqlStreamStore
                         .ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken)
                         .NotOnCapturedContext();
 
-                    var messages = new List<(StreamMessage, int?)>();
                     if (!reader.HasRows)
                     {
                         return new ReadAllPage(
@@ -47,6 +46,8 @@ namespace SqlStreamStore
                             readNext,
                             Array.Empty<StreamMessage>());
                     }
+
+                    var messages = new List<(StreamMessage, int?)>();
 
                     while (await reader.ReadAsync(cancellationToken).NotOnCapturedContext())
                     {

--- a/src/SqlStreamStore.MySql/MySqlStreamStore.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStore.cs
@@ -22,6 +22,7 @@
         private readonly Func<MySqlConnection> _createConnection;
         private readonly Schema _schema;
         private readonly Lazy<IStreamStoreNotifier> _streamStoreNotifier;
+        private readonly ScriptsV1.Scripts _scripts;
 
         public const int CurrentVersion = 1;
 
@@ -46,6 +47,7 @@
                 return settings.CreateStreamStoreNotifier.Invoke(this);
             });
             _schema = new Schema();
+            _scripts = new ScriptsV1.Scripts();
         }
 
         /// <summary>

--- a/src/SqlStreamStore.MySql/ScriptsV1/ReadAllForward.sql
+++ b/src/SqlStreamStore.MySql/ScriptsV1/ReadAllForward.sql
@@ -1,0 +1,14 @@
+SELECT streams.id_original,
+        streams.max_age,
+        messages.message_id,
+        messages.stream_version,
+        messages.position - 1,
+        messages.created_utc,
+        messages.type,
+        messages.json_metadata
+FROM messages
+        STRAIGHT_JOIN streams ON messages.stream_id_internal = streams.id_internal
+WHERE messages.position >= @_position + 1
+           
+ORDER BY messages.position
+LIMIT @_count;

--- a/src/SqlStreamStore.MySql/ScriptsV1/ReadAllForwardWithData.sql
+++ b/src/SqlStreamStore.MySql/ScriptsV1/ReadAllForwardWithData.sql
@@ -1,0 +1,15 @@
+SELECT streams.id_original,
+        streams.max_age,
+        messages.message_id,
+        messages.stream_version,
+        messages.position - 1,
+        messages.created_utc,
+        messages.type,
+        messages.json_metadata,
+        messages.json_data
+FROM messages
+        STRAIGHT_JOIN streams ON messages.stream_id_internal = streams.id_internal
+WHERE messages.position >= @_position + 1
+           
+ORDER BY messages.position
+LIMIT @_count;

--- a/src/SqlStreamStore.MySql/ScriptsV1/Scripts.cs
+++ b/src/SqlStreamStore.MySql/ScriptsV1/Scripts.cs
@@ -1,0 +1,87 @@
+﻿namespace SqlStreamStore.ScriptsV1
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Reflection;
+
+    public class Scripts
+    {
+        private readonly ConcurrentDictionary<string, string> _scripts 
+            = new ConcurrentDictionary<string, string>();
+
+        internal string AppendStreamExpectedVersionAny => GetScript(nameof(AppendStreamExpectedVersionAny));
+
+        internal string AppendStreamExpectedVersion => GetScript(nameof(AppendStreamExpectedVersion));
+
+        internal string AppendStreamExpectedVersionNoStream => GetScript(nameof(AppendStreamExpectedVersionNoStream));
+
+        internal string DeleteStreamAnyVersion => GetScript(nameof(DeleteStreamAnyVersion));
+
+        internal string DeleteStreamMessage => GetScript(nameof(DeleteStreamMessage));
+
+        internal string DeleteStreamExpectedVersion => GetScript(nameof(DeleteStreamExpectedVersion));
+
+        internal string DropAll => GetScript(nameof(DropAll));
+
+        internal string GetStreamMessageCount => GetScript(nameof(GetStreamMessageCount));
+
+        internal string CreateSchema => GetScript(nameof(CreateSchema));
+
+        internal string GetSchemaVersion => GetScript(nameof(GetSchemaVersion));
+
+        internal string GetStreamVersionOfMessageId => GetScript(nameof(GetStreamVersionOfMessageId));
+
+        internal string ReadHeadPosition => GetScript(nameof(ReadHeadPosition));
+
+        internal string ReadStreamHeadPosition => GetScript(nameof(ReadStreamHeadPosition));
+
+        internal string ReadStreamHeadVersion => GetScript(nameof(ReadStreamHeadVersion));
+
+        public string ReadAllForward => GetScript(nameof(ReadAllForward));
+
+        internal string ReadAllForwardWithData => GetScript(nameof(ReadAllForwardWithData));
+
+        internal string ReadAllBackward => GetScript(nameof(ReadAllBackward));
+
+        internal string ReadAllBackwardWithData => GetScript(nameof(ReadAllBackwardWithData));
+
+        internal string ReadStreamForward => GetScript(nameof(ReadStreamForward));
+
+        internal string ReadStreamForwardWithData => GetScript(nameof(ReadStreamForwardWithData));
+
+        internal string ReadStreamBackward => GetScript(nameof(ReadStreamBackward));
+
+        internal string ReadStreamBackwardWithData => GetScript(nameof(ReadStreamBackwardWithData));
+
+        internal string ReadMessageData => GetScript(nameof(ReadMessageData));
+
+        internal string SetStreamMetadata => GetScript(nameof(SetStreamMetadata));
+
+        internal string ListStreamIds => GetScript(nameof(ListStreamIds));
+
+        internal string ListStreamIdsStartingWith => GetScript(nameof(ListStreamIdsStartingWith));
+
+        internal string ListStreamIdsEndingWith => GetScript(nameof(ListStreamIdsEndingWith));
+
+        private string GetScript(string name) =>
+            _scripts.GetOrAdd(name, ScriptValueFactory(name));
+
+        private static Func<string, string> ScriptValueFactory(string name) =>
+            key =>
+            {
+                using (Stream stream = typeof(Scripts).GetTypeInfo().Assembly.GetManifestResourceStream("SqlStreamStore.ScriptsV1." + key + ".sql"))
+                {
+                    if (stream == null)
+                    {
+                        throw new Exception($"Embedded resource, {name}, not found. BUG!");
+                    }
+                    using (StreamReader reader = new StreamReader(stream))
+                    {
+                        return reader
+                            .ReadToEnd();
+                    }
+                }
+            };
+    }
+}

--- a/src/SqlStreamStore.MySql/SqlStreamStore.MySql.csproj
+++ b/src/SqlStreamStore.MySql/SqlStreamStore.MySql.csproj
@@ -7,10 +7,14 @@
     <AssemblyName>SqlStreamStore.MySql</AssemblyName>
     <PackageId>SqlStreamStore.MySql</PackageId>
     <RootNamespace>SqlStreamStore</RootNamespace>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="MySqlScripts\*.sql" Exclude="bin\**;obj\**;packages\**;@(EmbeddedResource)" />
+    <EmbeddedResource Include="ScriptsV1\*.sql"/>
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="ScriptsV1\ReadAllForward.sql" />
+    <None Remove="ScriptsV1\ReadAllForwardWIthData.sql" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MySqlConnector" Version="0.69.6" />

--- a/src/SqlStreamStore.TestUtils/MySql/MySqlContainer.cs
+++ b/src/SqlStreamStore.TestUtils/MySql/MySqlContainer.cs
@@ -13,23 +13,25 @@ namespace SqlStreamStore.TestUtils.MySql
     {
         private const string Image = "mysql:5.6";
         private const string ContainerName = "sql-stream-store-tests-mysql";
-        private const int Port = 3306;
+        private const int ContainerPort = 3306;
 
         private readonly string _databaseName;
+        private readonly uint _hostPort;
         private readonly IContainerService _containerService;
 
-        public MySqlContainer(string databaseName)
+        public MySqlContainer(string databaseName, string name = ContainerName, uint hostPort = ContainerPort)
         {
             _databaseName = databaseName;
+            _hostPort = hostPort;
 
             _containerService = new Builder()
                 .UseContainer()
-                .WithName(ContainerName)
+                .WithName(name)
                 .UseImage(Image)
                 .KeepRunning()
                 .ReuseIfExists()
                 .WithEnvironment("MYSQL_ALLOW_EMPTY_PASSWORD=1")
-                .ExposePort(Port, Port)
+                .ExposePort((int)hostPort, ContainerPort)
                 .Build();
         }
 
@@ -76,13 +78,14 @@ namespace SqlStreamStore.TestUtils.MySql
         private string DefaultConnectionString => new MySqlConnectionStringBuilder(ConnectionString)
             {
                 Database = null,
-                IgnorePrepare = false
+                IgnorePrepare = false,
+                Port = _hostPort,
             }.ConnectionString;
 
         private MySqlConnectionStringBuilder ConnectionStringBuilder => new MySqlConnectionStringBuilder
         {
             Database = _databaseName,
-            Port = Port,
+            Port = _hostPort,
             UserID = "root",
             Pooling = true,
             IgnorePrepare = false,


### PR DESCRIPTION
Fixes #432 

- Created seperate statement sql files for `ReadAllForward` and `ReadAllForwardWithData` that replaces the one stored proceedure.
- The ReadAllForward sql now use `STRAIGH_JOIN` as it appears the MySql optimiser was doing an incorrect join resulting in the slow read perf.
- No changes to schema, but there will be an unused sproc. This will be removed in a future schema version with migration
- Similar work will need to be applied to for other reads; they will come in subsequent PRs.