### PR TITLE
Improve Postgres backwards read perf

### DIFF
--- a/src/SqlStreamStore.Postgres/PgSqlScripts/ReadAll.sql
+++ b/src/SqlStreamStore.Postgres/PgSqlScripts/ReadAll.sql
@@ -36,9 +36,9 @@ BEGIN
       WHERE (CASE
                WHEN _forwards THEN __schema__.messages.position >= _position
                ELSE __schema__.messages.position <= _position END)
-      ORDER BY (CASE
-                  WHEN _forwards THEN __schema__.messages.position
-                  ELSE -__schema__.messages.position END)
+      ORDER BY
+          (CASE WHEN _forwards THEN __schema__.messages.position END),
+          (CASE WHEN not _forwards THEN __schema__.messages.position END) DESC
       LIMIT _count
   )
   SELECT * FROM messages LIMIT _count;


### PR DESCRIPTION
A bit of investigation into #428 lead me to the fact that the read all backwards query on Postgres had a very suboptimal execution plan

```sql
EXPLAIN ANALYZE SELECT public.streams.id_original,
       public.messages.message_id,
       public.messages.stream_version,
       public.messages.position,
       public.messages.created_utc,
       public.messages.type,
       public.messages.json_metadata,
       public.messages.json_data,
       public.streams.max_age
FROM public.streams
         INNER JOIN public.messages ON public.messages.stream_id_internal = public.streams.id_internal
WHERE public.messages.position < 9223372036854775807 
ORDER BY -public.messages.position
LIMIT 1;
```

```
Limit  (cost=42045.40..42045.51 rows=1 width=396) (actual time=12035.650..12041.211 rows=1 loops=1)
  ->  Gather Merge  (cost=42045.40..215783.99 rows=1489084 width=396) (actual time=12035.639..12041.163 rows=1 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Sort  (cost=41045.37..42906.73 rows=744542 width=396) (actual time=12032.333..12032.385 rows=1 loops=3)
"              Sort Key: ((- messages.""position""))"
              Sort Method: top-N heapsort  Memory: 27kB
              Worker 0:  Sort Method: top-N heapsort  Memory: 27kB
              Worker 1:  Sort Method: top-N heapsort  Memory: 27kB
              ->  Parallel Hash Join  (cost=2075.98..37322.66 rows=744542 width=396) (actual time=214.691..9040.367 rows=595747 loops=3)
                    Hash Cond: (messages.stream_id_internal = streams.id_internal)
                    ->  Parallel Seq Scan on messages  (cost=0.00..31430.78 rows=744542 width=346) (actual time=0.025..2985.246 rows=595747 loops=3)
"                          Filter: (""position"" < '9223372036854775807'::bigint)"
                    ->  Parallel Hash  (cost=1583.77..1583.77 rows=39377 width=50) (actual time=214.261..214.274 rows=22285 loops=3)
                          Buckets: 131072  Batches: 1  Memory Usage: 6304kB
                          ->  Parallel Seq Scan on streams  (cost=0.00..1583.77 rows=39377 width=50) (actual time=0.040..107.158 rows=22285 loops=3)
Planning Time: 0.215 ms
Execution Time: 12041.291 ms
```

By changing the order by clause from `-position` to `position DESC` the plan changes to

```
Limit  (cost=0.72..1.07 rows=1 width=388) (actual time=0.047..0.081 rows=1 loops=1)
  ->  Nested Loop  (cost=0.72..632449.28 rows=1786902 width=388) (actual time=0.038..0.059 rows=1 loops=1)
        ->  Index Scan Backward using pk_messages on messages  (cost=0.43..73010.22 rows=1786902 width=346) (actual time=0.011..0.015 rows=1 loops=1)
"              Index Cond: (""position"" < '9223372036854775807'::bigint)"
        ->  Index Scan using pk_streams on streams  (cost=0.29..0.31 rows=1 width=50) (actual time=0.011..0.015 rows=1 loops=1)
              Index Cond: (id_internal = messages.stream_id_internal)
Planning Time: 0.202 ms
Execution Time: 0.123 ms
```